### PR TITLE
노드 좌표 반환 API 구현

### DIFF
--- a/backend/src/node/node.controller.ts
+++ b/backend/src/node/node.controller.ts
@@ -1,7 +1,24 @@
-import { Controller } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+} from '@nestjs/common';
 import { NodeService } from './node.service';
 
 @Controller('node')
 export class NodeController {
   constructor(private readonly nodeService: NodeService) {}
+
+  @Get(':id/coordinates')
+  async getCoordinates(@Param('id', ParseIntPipe) id: number) {
+    try {
+      return await this.nodeService.getCoordinates(id);
+    } catch (error) {
+      // ! 의미상 204가 더 맞는 것 같은데, 보낼 방법이 없음
+      // TODO: express 에서 Response 가져와서 .status(204)로 보내는게 적합한지 토의 필요
+      throw new NotFoundException(error.message);
+    }
+  }
 }

--- a/backend/src/node/node.repository.ts
+++ b/backend/src/node/node.repository.ts
@@ -7,4 +7,8 @@ export class NodeRepository extends Repository<Node> {
   constructor(private dataSource: DataSource) {
     super(Node, dataSource.createEntityManager());
   }
+
+  async findById(id: number): Promise<Node | null> {
+    return await this.findOneBy({ id });
+  }
 }

--- a/backend/src/node/node.service.spec.ts
+++ b/backend/src/node/node.service.spec.ts
@@ -1,18 +1,45 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NodeService } from './node.service';
+import { NodeRepository } from './node.repository';
 
 describe('NodeService', () => {
   let service: NodeService;
+  let repository: NodeRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [NodeService],
+      providers: [
+        NodeService,
+        {
+          provide: NodeRepository,
+          useValue: {
+            findById: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<NodeService>(NodeService);
+    repository = module.get<NodeRepository>(NodeRepository);
+    jest
+      .spyOn(repository, 'findById')
+      .mockResolvedValue({ id: 1, x: 1, y: 2 } as any);
   });
 
-  it('should be defined', () => {
+  it('서비스 클래스가 정상적으로 인스턴스화된다.', () => {
     expect(service).toBeDefined();
+  });
+
+  it('노드 아이디를 받아 해당 노드의 좌표를 반환한다.', async () => {
+    const coordinates = await service.getCoordinates(1);
+    expect(coordinates).toEqual({ x: 1, y: 2 });
+    expect(repository.findById).toHaveBeenCalledWith(1);
+  });
+
+  it('노드를 찾을 수 없으면 예외를 던진다.', async () => {
+    jest.spyOn(repository, 'findById').mockResolvedValue(null);
+    await expect(service.getCoordinates(1)).rejects.toThrow(
+      '해당 노드를 찾을 수 없습니다.',
+    );
   });
 });

--- a/backend/src/node/node.service.ts
+++ b/backend/src/node/node.service.ts
@@ -1,4 +1,18 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { NodeRepository } from './node.repository';
 
 @Injectable()
-export class NodeService {}
+export class NodeService {
+  constructor(private readonly nodeRepository: NodeRepository) {}
+
+  async getCoordinates(id: number) {
+    const node = await this.nodeRepository.findById(id);
+    if (!node) {
+      throw new NotFoundException('해당 노드를 찾을 수 없습니다.');
+    }
+    return {
+      x: node.x,
+      y: node.y,
+    };
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
    
close #20 
    
## 📝 작업 내용
    
- 특정 노드의 ID를 받아 좌표를 반환하는 API 구현 (`GET /node/:id/coordinates`)
    
## 💬 리뷰 요구사항(선택)
    
- 최대한 간단한 형태로 구현해보았습니다.
- TODO 주석으로 달았지만, `:id` 파라미터가 잘못 넘어왔을 때의 처리를 컨벤션으로 통일해야 할 것 같습니다.
    - 없는 엔드포인트는 확실히 **404**가 맞지만, 성공한 요청이 null을 보낼 때 또한 **404**로 처리해야 할까요?