### PR TITLE
페이지 목록 반환 API 구현

### DIFF
--- a/backend/src/page/page.controller.ts
+++ b/backend/src/page/page.controller.ts
@@ -1,7 +1,12 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { PageService } from './page.service';
 
 @Controller('page')
 export class PageController {
   constructor(private readonly pageService: PageService) {}
+
+  @Get()
+  async getPages() {
+    return await this.pageService.getPages();
+  }
 }

--- a/backend/src/page/page.repository.ts
+++ b/backend/src/page/page.repository.ts
@@ -7,4 +7,8 @@ export class PageRepository extends Repository<Page> {
   constructor(private dataSource: DataSource) {
     super(Page, dataSource.createEntityManager());
   }
+
+  async findAll(): Promise<Page[]> {
+    return await this.find();
+  }
 }

--- a/backend/src/page/page.service.spec.ts
+++ b/backend/src/page/page.service.spec.ts
@@ -1,18 +1,35 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PageService } from './page.service';
+import { PageRepository } from './page.repository';
 
 describe('PageService', () => {
   let service: PageService;
+  let repository: PageRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PageService],
+      providers: [
+        PageService,
+        {
+          provide: PageRepository,
+          useValue: {
+            findAll: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<PageService>(PageService);
+    repository = module.get<PageRepository>(PageRepository);
   });
 
-  it('should be defined', () => {
+  it('서비스 클래스가 정상적으로 인스턴스화된다.', () => {
     expect(service).toBeDefined();
+  });
+
+  it('모든 페이지 목록을 조회할 수 있다.', async () => {
+    jest.spyOn(repository, 'findAll').mockResolvedValue([]);
+    const result = await service.getPages();
+    expect(result).toEqual([]);
   });
 });

--- a/backend/src/page/page.service.ts
+++ b/backend/src/page/page.service.ts
@@ -4,4 +4,8 @@ import { PageRepository } from './page.repository';
 @Injectable()
 export class PageService {
   constructor(private pageRepository: PageRepository) {}
+
+  async getPages() {
+    return await this.pageRepository.findAll();
+  }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
    
close #19 
    
## 📝 작업 내용
    
- 데이터베이스에 존재하는 모든 페이지를 반환하는 API를 구현했습니다.
    - 추후 워크스페이스 개념을 도입하면, 파라미터 `:workspace_id` 를 통해 필터링하여 반환하는 로직으로 수정이 필요합니다. 

## 💬 리뷰 요구사항(선택)
    
- 너무 간단한 것 같은데 이 의도로 작성된 이슈가 맞을까요...? #18 이랑 무슨 차이가 있나요??
