### PR TITLE
NoteNode 타입 및 커스텀 컴포넌트 구현, 쿼리 결과로 노드 렌더링 구현

### DIFF
--- a/frontend/src/components/canvas/NoteNode.tsx
+++ b/frontend/src/components/canvas/NoteNode.tsx
@@ -1,0 +1,51 @@
+import { Handle, NodeProps, Position, type Node } from "@xyflow/react";
+import usePageStore from "@/store/usePageStore";
+
+export type NoteNodeData = { title: string; id: number };
+export type NoteNodeType = Node<NoteNodeData, "note">;
+
+export function NoteNode({ data }: NodeProps<NoteNodeType>) {
+  const { setCurrentPage } = usePageStore();
+
+  const handleNodeClick = () => {
+    const id = data.id;
+    if (id === undefined || id === null) {
+      return;
+    }
+
+    setCurrentPage(id);
+  };
+
+  return (
+    <div
+      className="rounded-md border-[1px] border-black bg-neutral-100 p-2"
+      onClick={handleNodeClick}
+    >
+      <Handle
+        type="source"
+        id="left"
+        position={Position.Left}
+        isConnectable={true}
+      />
+      <Handle
+        type="source"
+        id="top"
+        position={Position.Top}
+        isConnectable={true}
+      />
+      <Handle
+        type="source"
+        id="right"
+        position={Position.Right}
+        isConnectable={true}
+      />
+      <Handle
+        type="source"
+        id="bottom"
+        position={Position.Bottom}
+        isConnectable={true}
+      />
+      {data.title}
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
    
> #51 
    
## 📝 작업 내용
    
- `NoteNode` 타입 및 `<NoteNode />` 커스텀 컴포넌트 구현
-  `usePages()` 쿼리 결과로 노드 렌더링 
