### PR TITLE
Sidebar 컴포넌트에서 text 선택이 불가능하게 수정

### DIFF
--- a/frontend/src/components/commons/button/index.tsx
+++ b/frontend/src/components/commons/button/index.tsx
@@ -10,7 +10,10 @@ export default function Button({ className, onClick, children }: ButtonProps) {
   return (
     <button
       onClick={onClick}
-      className={cn("rounded-md px-8 py-2 transition-colors", className)}
+      className={cn(
+        "select-none rounded-md px-8 py-2 transition-colors",
+        className,
+      )}
     >
       {children}
     </button>

--- a/frontend/src/components/sidebar/NoteList.tsx
+++ b/frontend/src/components/sidebar/NoteList.tsx
@@ -4,6 +4,7 @@ import RemoveNoteModal from "./RemoveNoteModal";
 
 import { useNoteList } from "@/hooks/useNoteList";
 import { cn } from "@/lib/utils";
+import Button from "../commons/button";
 
 interface NoteListProps {
   className?: string;
@@ -31,7 +32,7 @@ export default function NoteList({ className }: NoteListProps) {
         onCloseModal={onCloseModal}
       />
       {data.map(({ id, title }) => (
-        <button
+        <Button
           onClick={() => handleNoteClick(id)}
           key={id}
           className="group flex flex-row justify-between rounded-sm px-3 py-1 hover:bg-neutral-100"
@@ -48,7 +49,7 @@ export default function NoteList({ className }: NoteListProps) {
           >
             <Trash2 width={20} height={20} />
           </span>
-        </button>
+        </Button>
       ))}
     </div>
   );

--- a/frontend/src/components/sidebar/Tools.tsx
+++ b/frontend/src/components/sidebar/Tools.tsx
@@ -2,6 +2,7 @@ import { PencilLine } from "lucide-react";
 
 import { useCreatePage, usePages } from "@/hooks/usePages";
 import usePageStore from "@/store/usePageStore";
+import Button from "../commons/button";
 
 // TODO: 에디터 렌더링할 때 필요한 id 받아오는 방법 수정 해야할듯
 export default function Tools() {
@@ -14,7 +15,7 @@ export default function Tools() {
   }
 
   return (
-    <button
+    <Button
       className="flex flex-row items-center gap-1 rounded-sm px-2 py-1 font-medium hover:bg-neutral-100"
       onClick={() => {
         createMutation.mutate({
@@ -38,6 +39,6 @@ export default function Tools() {
         <PencilLine width={20} height={20} widths={1} color="#7f796d" />
       </div>
       <div className="text-neutral-600">새 페이지 작성</div>
-    </button>
+    </Button>
   );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- fixes #53 

## 📝 작업 내용
- `<Button />` 컴포넌트에 `select-none` 추가
- `<Sidebar />` 컴포넌트에서 수정된 `<Button />` 사용하게 변경
    
### 스크린샷 (선택)
    
## 💬 리뷰 요구사항(선택)
    
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
