### PR TITLE
사이드바 페이지 목록 text overflow 수정

### DIFF
--- a/frontend/src/components/sidebar/NoteList.tsx
+++ b/frontend/src/components/sidebar/NoteList.tsx
@@ -36,9 +36,7 @@ export default function NoteList({ className }: NoteListProps) {
           key={id}
           className="group flex flex-row justify-between rounded-sm px-3 py-1 hover:bg-neutral-100"
         >
-          <div className="flex flex-row gap-1">
-            <div>{title}</div>
-          </div>
+          <div className="w-full truncate text-start">{title}</div>
           <span
             className="hidden text-neutral-400 transition-colors hover:text-red-500 group-hover:block"
             onClick={(e) => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- fixes #83
## 📝 작업 내용
- 사이드바 페이지 목록 text `overflow` 수정
### 스크린샷 (선택)
![스크린샷 2024-11-10 오전 12 59 15](https://github.com/user-attachments/assets/7250c541-c0d8-45a4-b903-a210576cb52d)

    
## 💬 리뷰 요구사항(선택)
- 나중에 `<Button />` 자체에 넣어야할 것 같긴 해요..!