### PR TITLE
기본 커서 컴포넌트 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^11.11.11",
     "highlight.js": "^11.10.0",
     "lowlight": "^3.1.0",
     "lucide-react": "^0.454.0",

--- a/frontend/src/components/cursor/index.tsx
+++ b/frontend/src/components/cursor/index.tsx
@@ -1,0 +1,40 @@
+import { motion } from "framer-motion";
+
+export interface Coors {
+  x: number;
+  y: number;
+}
+
+interface CursorProps {
+  coors: Coors;
+  color?: string;
+}
+
+export default function Cursor({ coors, color = "#ffb8b9" }: CursorProps) {
+  const { x, y } = coors;
+
+  return (
+    <motion.div
+      className="pointer-events-none absolute left-0 top-0 z-50 h-6 w-6"
+      initial={{ x, y }}
+      animate={{ x, y }}
+      transition={{
+        type: "spring",
+        bounce: 0.6,
+        damping: 30,
+        mass: 0.8,
+        stiffness: 350,
+        restSpeed: 0.01,
+      }}
+    >
+      <svg viewBox="0 0 94 99" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M2.40255 5.31234C1.90848 3.6645 3.58743 2.20312 5.15139 2.91972L90.0649 41.8264C91.7151 42.5825 91.5858 44.9688 89.8637 45.5422L54.7989 57.2186C53.3211 57.7107 52.0926 58.7582 51.3731 60.1397L33.0019 95.4124C32.1726 97.0047 29.8279 96.7826 29.3124 95.063L2.40255 5.31234Z"
+          fill={color}
+          stroke="black"
+          stroke-width="4"
+        />
+      </svg>
+    </motion.div>
+  );
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2233,6 +2233,13 @@ fraction.js@^4.3.7:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
 
+framer-motion@^11.11.11:
+  version "11.11.11"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.11.11.tgz#3c058c97ec134afdce77caa20396f0fd82d63b7d"
+  integrity sha512-tuDH23ptJAKUHGydJQII9PhABNJBpB+z0P1bmgKK9QFIssHGlfPd6kxMq00LSKwE27WFsb2z0ovY0bpUyMvfRw==
+  dependencies:
+    tslib "^2.4.0"
+
 framework-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/framework-utils/-/framework-utils-1.1.0.tgz#a3b528bce838dfd623148847dc92371b09d0da2d"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
    
- closes #86 
    
## 📝 작업 내용
- 커서 SVG 만들기
- framer-motion 추가
- prop으로 받은 x, y 좌표에 위치하는 기본 커서 컴포넌트 구현
### 스크린샷 (선택)
    

https://github.com/user-attachments/assets/323d36fa-14c9-44c6-8ad9-a7a86c7defb6


## 💬 리뷰 요구사항(선택)
    
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- https://github.com/djk01281/live-share/blob/main/app/editor/components/Cursor/index.tsx