### PR TITLE
현재 페이지 삭제 시, 에디터 내용이 바뀌지 않는 문제

### DIFF
--- a/frontend/src/hooks/useNoteList.ts
+++ b/frontend/src/hooks/useNoteList.ts
@@ -28,6 +28,7 @@ export const useNoteList = () => {
 
     deleteMutation.mutate({ id: noteIdToDelete });
     setIsModalOpen(false);
+    setCurrentPage(null);
   };
 
   const onCloseModal = () => {

--- a/frontend/src/store/usePageStore.ts
+++ b/frontend/src/store/usePageStore.ts
@@ -2,12 +2,12 @@ import { create } from "zustand";
 
 interface PageStore {
   currentPage: number | null;
-  setCurrentPage: (currentPage: number) => void;
+  setCurrentPage: (currentPage: number | null) => void;
 }
 
 const usePageStore = create<PageStore>((set) => ({
   currentPage: null,
-  setCurrentPage: (currentPage: number) => set({ currentPage }),
+  setCurrentPage: (currentPage: number | null) => set({ currentPage }),
 }));
 
 export default usePageStore;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
    
> #75 
    
## 📝 작업 내용
    
페이지 삭제 시, currentPage를 null로 설정해서 에디터를 닫았습니다.
    
### 스크린샷 (선택)

https://github.com/user-attachments/assets/6d1630a1-f1ad-47a3-9f3a-236adb618b70
