### PR TITLE
.env 파일 전송

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,16 +36,19 @@ jobs:
           aws configure set aws_secret_access_key $NCLOUD_SECRET_ACCESS_KEY
           aws configure set region ap-northeast-2
           aws --endpoint-url=https://kr.object.ncloudstorage.com s3 cp ./frontend/dist s3://octodocs/ --recursive --debug
-
-
   backend-CD:
+    runs-on: ubuntu-latest
 
-    # 배포용 쉘 스크립트 파일 전송
-    - name: Copy deploy.sh to remote server
-      uses: appleboy/scp-action@v0.1.1
-      with:
-        host: ${{ secrets.REMOTE_DEV_IP }}
-        username: ${{ secrets.REMOTE_USER }}
-        key: ${{ secrets.REMOTE_PRIVATE_KEY }}
-        source: ./deploy.sh
-        target: /home/root/deploy.sh
+    steps:
+      # 코드 체크아웃
+      - name: Checkout code
+        uses: actions/checkout@v3
+      # 배포용 쉘 스크립트 파일 전송
+      - name: Copy deploy.sh to remote server
+        uses: appleboy/scp-action@v0.1.1
+        with:
+          host: ${{ secrets.REMOTE_DEV_IP }}
+          username: ${{ secrets.REMOTE_USER }}
+          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
+          source: ./deploy.sh
+          target: /home/root/deploy.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - feature-be-#110
 
 jobs:
-  create-directory:
+  frontend-CD:
     runs-on: ubuntu-latest
 
     steps:
@@ -37,19 +37,15 @@ jobs:
           aws configure set region ap-northeast-2
           aws --endpoint-url=https://kr.object.ncloudstorage.com s3 cp ./frontend/dist s3://octodocs/ --recursive --debug
 
-      # 패키지 설치 및 Nest.js 빌드
-      - name: Install dependencies and build
-        run: |
-          cd backend
-          npm install
-          npm run build
 
-      # 배포용 쉘 스크립트 파일 전송
-      - name: Copy deploy.sh to remote server
-        uses: appleboy/scp-action@v0.1.1
-        with:
-          host: ${{ secrets.REMOTE_DEV_IP }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
-          source: ./deploy.sh
-          target: /home/root/deploy.sh
+  backend-CD:
+
+    # 배포용 쉘 스크립트 파일 전송
+    - name: Copy deploy.sh to remote server
+      uses: appleboy/scp-action@v0.1.1
+      with:
+        host: ${{ secrets.REMOTE_DEV_IP }}
+        username: ${{ secrets.REMOTE_USER }}
+        key: ${{ secrets.REMOTE_PRIVATE_KEY }}
+        source: ./deploy.sh
+        target: /home/root/deploy.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v3
       # 배포용 쉘 스크립트 파일 전송
       - name: Copy deploy.sh to remote server
-        uses: appleboy/scp-action@v0.1.1
+        uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.REMOTE_DEV_IP }}
           username: ${{ secrets.REMOTE_USER }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,15 @@ jobs:
       - name: Create .env file
         run: |
           echo "${{secrets.DEVELOPMENT_ENV}}" > ./.env
+      # .env 파일 전송
+      - name: Copy deploy.sh to remote server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.REMOTE_DEV_IP }}
+          username: ${{ secrets.REMOTE_USER }}
+          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
+          source: ./.env
+          target: /home/root/app/autodocs
 
       # 배포용 쉘 스크립트 파일 전송
       - name: Copy deploy.sh to remote server

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Create Directory on Remote Server
 on:
   push:
     branches:
-      - feature-be-#110
+      - develop
 
 jobs:
   frontend-CD:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,12 @@ jobs:
       # 코드 체크아웃
       - name: Checkout code
         uses: actions/checkout@v3
+
+      # .env 파일 생성 후 붙여넣기
+      - name: Create .env file
+        run: |
+          echo "${{secrets.DEVELOPMENT_ENV}}" > ./.env
+
       # 배포용 쉘 스크립트 파일 전송
       - name: Copy deploy.sh to remote server
         uses: appleboy/scp-action@master
@@ -51,4 +57,13 @@ jobs:
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           source: ./deploy.sh
-          target: /home/root/deploy.sh
+          target: /home/root
+      # 쉘 스크립트 실행
+      - name: Run command on remote server
+        uses: appleboy/ssh-action@v0.1.3
+        with:
+          host: ${{ secrets.REMOTE_DEV_IP }}
+          username: ${{ secrets.REMOTE_USER }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          script: |
+            sh /home/root/deploy.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,10 +60,10 @@ jobs:
           target: /home/root
       # 쉘 스크립트 실행
       - name: Run command on remote server
-        uses: appleboy/ssh-action@v0.1.3
+        uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.REMOTE_DEV_IP }}
           username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.PRIVATE_KEY }}
+          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           script: |
             sh /home/root/deploy.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Create Directory on Remote Server
 on:
   push:
     branches:
-      - main
+      - feature-be-#110
 
 jobs:
   create-directory:
@@ -48,7 +48,7 @@ jobs:
       - name: Copy deploy.sh to remote server
         uses: appleboy/scp-action@v0.1.1
         with:
-          host: ${{ secrets.REMOTE_IP }}
+          host: ${{ secrets.REMOTE_DEV_IP }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           source: ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ fi
 
 # 의존성 설치 및 애플리케이션 시작
 echo "의존성 설치 중..."
-npm install
+yarn install
 
 echo "애플리케이션 시작 중..."
-nohup npm start &
+nohup yarn start &


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #136

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->
.env 파일은 .gitignore에 등록되어 깃허브에 올라가지 않습니다.

.env 파일을 github action secrets에 등록하고 push가 발생했을 때 .env 파일을 원격 서버로 전송합니다.

그 후 deploy.sh도 원격 서버로 보내서 쉘 스크립트 파일을 실행합니다.

deploy.sh는 github에서 최신 변경 사항을 가져온 다음 3000번 포트에 서버를 띄웁니다.
- .

## 📢 리뷰 요구사항 (선택)

지금 뭔가 CD를 야매로 한 것 같아서 걱정이 되네요.

git에서 최신 정보를 pull 해 올 경우 .env 파일이 없어서 데이터베이스 연동이 안됩니다.

이를 해결하기 위해 github action secrets에 .env를 등록한 다음 이 .env 파일을 원격 서버로 보내도록 하고 있습니다.

.env 파일을 노출시키지 않으면서 CD를 구축하기 위해 선택한 방법인데 혹시 다른 좋은 방법 있으시다면 공유해주시면 감사하겠습니다!!

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
