### PR TITLE
에디터 업데이트 시 노드에 반영하는 기능 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "fast-diff": "^1.3.0",
     "framer-motion": "^11.11.11",
     "highlight.js": "^11.10.0",
     "lowlight": "^3.1.0",

--- a/frontend/src/components/EditorView.tsx
+++ b/frontend/src/components/EditorView.tsx
@@ -6,11 +6,7 @@ import * as Y from "yjs";
 
 import Editor from "./editor";
 import usePageStore from "@/store/usePageStore";
-import {
-  usePage,
-  useUpdatePage,
-  useOptimisticUpdatePage,
-} from "@/hooks/usePages";
+import { usePage, useUpdatePage } from "@/hooks/usePages";
 import EditorLayout from "./layout/EditorLayout";
 import EditorTitle from "./editor/EditorTitle";
 import SaveStatus from "./editor/ui/SaveStatus";
@@ -36,7 +32,7 @@ export default function EditorView() {
   const pageContent = page?.content ?? {};
 
   const updatePageMutation = useUpdatePage();
-  const optimisticUpdatePageMutation = useOptimisticUpdatePage({
+  /*   const optimisticUpdatePageMutation = useOptimisticUpdatePage({
     id: currentPage ?? 0,
   });
 
@@ -54,7 +50,7 @@ export default function EditorView() {
         onError: () => setSaveStatus("unsaved"),
       },
     );
-  };
+  }; */
 
   const handleEditorUpdate = useDebouncedCallback(
     async ({ editor }: { editor: EditorInstance }) => {
@@ -91,7 +87,11 @@ export default function EditorView() {
   return (
     <EditorLayout>
       <SaveStatus saveStatus={saveStatus} />
-      <EditorTitle title={pageTitle} onTitleChange={handleTitleChange} />
+      <EditorTitle
+        key={currentPage}
+        currentPage={currentPage}
+        pageContent={pageContent}
+      />
       <Editor
         key={ydoc.guid}
         initialContent={pageContent}

--- a/frontend/src/components/editor/EditorTitle.tsx
+++ b/frontend/src/components/editor/EditorTitle.tsx
@@ -1,19 +1,39 @@
+import useYDocStore from "@/store/useYDocStore";
+import { useYText } from "@/hooks/useYText";
+import { useOptimisticUpdatePage } from "@/hooks/usePages";
+import { JSONContent } from "novel";
+
 interface EditorTitleProps {
-  title?: string;
-  onTitleChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  currentPage: number;
+  pageContent: JSONContent;
 }
 
 export default function EditorTitle({
-  title,
-  onTitleChange,
+  currentPage,
+  pageContent,
 }: EditorTitleProps) {
+  const { ydoc } = useYDocStore();
+  const { input, setYText } = useYText(ydoc, currentPage);
+
+  const optimisticUpdatePageMutation = useOptimisticUpdatePage({
+    id: currentPage ?? 0,
+  });
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setYText(e.target.value);
+
+    optimisticUpdatePageMutation.mutate({
+      pageData: { title: e.target.value, content: pageContent },
+    });
+  };
+
   return (
     <div className="p-12 pb-0">
       <input
         type="text"
+        value={input as string}
         className="w-full text-xl font-bold outline-none"
-        value={title}
-        onChange={onTitleChange}
+        onChange={handleTitleChange}
       />
     </div>
   );

--- a/frontend/src/hooks/useYText.ts
+++ b/frontend/src/hooks/useYText.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import * as Y from "yjs";
+import diff from "fast-diff";
+
+function diffToDelta(diffResult) {
+  return diffResult.map(([op, value]) =>
+    op === diff.INSERT
+      ? { insert: value }
+      : op === diff.EQUAL
+        ? { retain: value.length }
+        : op === diff.DELETE
+          ? { delete: value.length }
+          : null,
+  );
+}
+
+export const useYText = (ydoc: Y.Doc, currentPage: number) => {
+  const yText = ydoc.getMap("title").get(`title_${currentPage}`) as Y.Text;
+
+  const [input, setInput] = useState(yText.toString());
+
+  const setYText = (textNew: string) => {
+    const delta = diffToDelta(diff(input, textNew));
+    yText.applyDelta(delta);
+  };
+
+  yText.observe(() => {
+    setInput(yText.toString());
+  });
+
+  return { input, setYText };
+};

--- a/frontend/src/store/useYDocStore.ts
+++ b/frontend/src/store/useYDocStore.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+import * as Y from "yjs";
+
+interface YDocStore {
+  ydoc: Y.Doc;
+  setYDoc: (ydoc: Y.Doc) => void;
+}
+
+const useYDocStore = create<YDocStore>((set) => ({
+  ydoc: new Y.Doc(),
+  setYDoc: (ydoc: Y.Doc) => set({ ydoc }),
+}));
+
+export default useYDocStore;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2218,6 +2218,11 @@ fast-deep-equal@^3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-diff@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
+  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
+
 fast-glob@^3.3.0, fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"


### PR DESCRIPTION
## 🔖 연관된 이슈

- closes #146 


## 📂 작업 내용

- Y.Doc을 Global State로 관리한다.
- 이 전역 Y.Doc는 에디터와 캔버스에서 공유된다.
- Y.Doc에 Y.Text를 추가하여 에디터 제목을 실시간 동시 편집이 가능하게 한다.


## 📑 참고 자료 & 스크린샷 (선택)


https://github.com/user-attachments/assets/4e42845c-f49d-44f5-ab5c-f1ddbfaa2ebe

랜덤으로 노드 위치가 바뀌는 문제는 추후 수정할 예정
