### PR TITLE
서버 배포 과정 로깅

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "${{secrets.DEVELOPMENT_ENV}}" > ./.env
       # .env 파일 전송
-      - name: Copy deploy.sh to remote server
+      - name: Copy .env to remote server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.REMOTE_DEV_IP }}
@@ -60,9 +60,9 @@ jobs:
       # sh 실행
       - name: Connect to Remote Server and Run Commands
         env:
-          REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+          REMOTE_HOST: ${{ secrets.REMOTE_DEV_IP }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
-          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
         run: |
           echo "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,9 +107,6 @@ jobs:
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
         run: |
-          mkdir ~/.ssh
-          echo "$SSH_KEY" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
           ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
             DIR="/home/root/app/octodocs"
             cd "$DIR"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,8 @@ jobs:
             DIR="/home/root/app/octodocs"
             cd "$DIR"
             cd backend
-            nohup yarn start & disown
+            nohup yarn start &
+            exit
           EOF
       # # 배포용 쉘 스크립트 파일 전송
       # - name: Copy deploy.sh to remote server

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
         run: |
-          ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST "cd /home/root/app/octodocs; sh deploy.sh"
+          ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST "cd /home/root/app/octodocs; nohup yarn start > nohup.out 2> nohup.err < /dev/null &"
 
       # # 배포용 쉘 스크립트 파일 전송
       # - name: Copy deploy.sh to remote server

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,8 +75,9 @@ jobs:
             # Move to backend directory
             cd backend
 
-            # Install dependencies and start application
+            # Install dependencies
             echo "의존성 설치"
+            yarn -v
             yarn install
 
             # Check and kill existing process
@@ -89,10 +90,6 @@ jobs:
             else
                 echo "실행 중인 프로세스가 없습니다."
             fi
-
-
-            echo "시작"
-            yarn start
           EOF
       # .env 파일 전송
       - name: Copy .env to remote server

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Create Directory on Remote Server
 on:
   push:
     branches:
-      - bug-be-#143
+      - develop
 
 jobs:
   frontend-CD:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,15 +100,6 @@ jobs:
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           source: ./.env
           target: /home/root/app/octodocs
-      # .sh 파일 전송
-      - name: Copy deploy.sh to remote server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.REMOTE_DEV_IP }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
-          source: ./deploy.sh
-          target: /home/root/app/octodocs
       # yarn start
       - name: yarn start
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,10 +107,15 @@ jobs:
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
         run: |
-          DIR="/home/root/app/octodocs"
-          cd "$DIR"
-          cd backend
-          yarn start
+          mkdir ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
+            DIR="/home/root/app/octodocs"
+            cd "$DIR"
+            cd backend
+            yarn start
+          EOF
       # # 배포용 쉘 스크립트 파일 전송
       # - name: Copy deploy.sh to remote server
       #   uses: appleboy/scp-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Create Directory on Remote Server
 on:
   push:
     branches:
-      - develop
+      - bug-be-#143
 
 jobs:
   frontend-CD:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
           SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
         run: |
           DIR="/home/root/app/octodocs"
-          cd DIR
+          cd "$DIR"
           cd backend
           yarn start
       # # 배포용 쉘 스크립트 파일 전송

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
             DIR="/home/root/app/octodocs"
             cd "$DIR"
             cd backend
-            nohup yarn start &
+            nohup yarn start & disown
           EOF
       # # 배포용 쉘 스크립트 파일 전송
       # - name: Copy deploy.sh to remote server

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
         run: |
-          mkdir ~/.ssh/id_rsa
+          mkdir ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
         run: |
+          mkdir ~/.ssh/id_rsa
           echo "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
             DIR="/home/root/app/octodocs"
             cd "$DIR"
             cd backend
-            yarn start
+            nohup yarn start &
           EOF
       # # 배포용 쉘 스크립트 파일 전송
       # - name: Copy deploy.sh to remote server

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,23 +56,66 @@ jobs:
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           source: ./.env
-          target: /home/root/app/autodocs
+          target: /home/root/app/actodocs
+      # sh 실행
+      - name: Connect to Remote Server and Run Commands
+        env:
+          REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+          REMOTE_USER: ${{ secrets.REMOTE_USER }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: |
+          echo "$SSH_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
+            DIR="/home/root/app/actodocs"
+            
+            # Check if directory exists
+            if [ -d "$DIR/backend" ]; then
+                echo "$DIR/backend 디렉토리가 존재합니다. 최신 버전으로 업데이트 중..."
+                cd "$DIR"
+                git pull
+            else
+                echo "$DIR/backend 디렉토리가 존재하지 않습니다. 클론 중..."
+                git clone https://github.com/boostcampwm-2024/web15-OctoDocs.git "$DIR"
+                cd "$DIR"
+            fi
 
-      # 배포용 쉘 스크립트 파일 전송
-      - name: Copy deploy.sh to remote server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.REMOTE_DEV_IP }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
-          source: ./deploy.sh
-          target: /home/root
-      # 쉘 스크립트 실행
-      - name: Run command on remote server
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.REMOTE_DEV_IP }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
-          script: |
-            sh /home/root/deploy.sh
+            # Move to backend directory
+            cd backend
+
+            # Check and kill existing process
+            EXISTING_PID=$(lsof -ti :3000)
+
+            if [ -n "$EXISTING_PID" ]; then
+                echo "프로세스 종료 중...: $EXISTING_PID"
+                kill -9 "$EXISTING_PID"
+                echo "$EXISTING_PID 프로세스 종료"
+            else
+                echo "실행 중인 프로세스가 없습니다."
+            fi
+
+            # Install dependencies and start application
+            echo "의존성 설치"
+            yarn install
+
+            echo "시작"
+            yarn start
+          EOF
+      # # 배포용 쉘 스크립트 파일 전송
+      # - name: Copy deploy.sh to remote server
+      #   uses: appleboy/scp-action@master
+      #   with:
+      #     host: ${{ secrets.REMOTE_DEV_IP }}
+      #     username: ${{ secrets.REMOTE_USER }}
+      #     key: ${{ secrets.REMOTE_PRIVATE_KEY }}
+      #     source: ./deploy.sh
+      #     target: /home/root
+      # # 쉘 스크립트 실행
+      # - name: Run command on remote server
+      #   uses: appleboy/ssh-action@master
+      #   with:
+      #     host: ${{ secrets.REMOTE_DEV_IP }}
+      #     username: ${{ secrets.REMOTE_USER }}
+      #     key: ${{ secrets.REMOTE_PRIVATE_KEY }}
+      #     script: |
+      #       sh /home/root/deploy.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,15 +48,6 @@ jobs:
       - name: Create .env file
         run: |
           echo "${{secrets.DEVELOPMENT_ENV}}" > ./.env
-      # .env 파일 전송
-      - name: Copy .env to remote server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.REMOTE_DEV_IP }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
-          source: ./.env
-          target: /home/root/app/actodocs
       # sh 실행
       - name: Connect to Remote Server and Run Commands
         env:
@@ -68,21 +59,25 @@ jobs:
           echo "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
-            DIR="/home/root/app/actodocs"
+            DIR="/home/root/app/octodocs"
             
             # Check if directory exists
-            if [ -d "$DIR/backend" ]; then
-                echo "$DIR/backend 디렉토리가 존재합니다. 최신 버전으로 업데이트 중..."
+            if [ -d "$DIR" ]; then
+                echo "$DIR 디렉토리가 존재합니다. 최신 버전으로 업데이트 중..."
                 cd "$DIR"
                 git pull
             else
-                echo "$DIR/backend 디렉토리가 존재하지 않습니다. 클론 중..."
+                echo "$DIR 디렉토리가 존재하지 않습니다. 클론 중..."
                 git clone https://github.com/boostcampwm-2024/web15-OctoDocs.git "$DIR"
                 cd "$DIR"
             fi
 
             # Move to backend directory
             cd backend
+
+            # Install dependencies and start application
+            echo "의존성 설치"
+            yarn install
 
             # Check and kill existing process
             EXISTING_PID=$(lsof -ti :3000)
@@ -95,13 +90,30 @@ jobs:
                 echo "실행 중인 프로세스가 없습니다."
             fi
 
-            # Install dependencies and start application
-            echo "의존성 설치"
-            yarn install
 
             echo "시작"
             yarn start
           EOF
+      # .env 파일 전송
+      - name: Copy .env to remote server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.REMOTE_DEV_IP }}
+          username: ${{ secrets.REMOTE_USER }}
+          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
+          source: ./.env
+          target: /home/root/app/octodocs
+      # yarn start
+      - name: yarn start
+        env:
+          REMOTE_HOST: ${{ secrets.REMOTE_DEV_IP }}
+          REMOTE_USER: ${{ secrets.REMOTE_USER }}
+          SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
+        run: |
+          DIR="/home/root/app/octodocs"
+          cd DIR
+          cd backend
+          yarn start
       # # 배포용 쉘 스크립트 파일 전송
       # - name: Copy deploy.sh to remote server
       #   uses: appleboy/scp-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,15 @@ jobs:
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           source: ./.env
           target: /home/root/app/octodocs
+      # .sh 파일 전송
+      - name: Copy deploy.sh to remote server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.REMOTE_DEV_IP }}
+          username: ${{ secrets.REMOTE_USER }}
+          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
+          source: ./deploy.sh
+          target: /home/root/app/octodocs
       # yarn start
       - name: yarn start
         env:
@@ -107,14 +116,8 @@ jobs:
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
         run: |
-          ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
-            DIR="/home/root/app/octodocs"
-            cd "$DIR"
-            cd backend
-            nohup yarn start &
-            disown
-            exit
-          EOF
+          ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST "cd /home/root/app/octodocs; sh deploy.sh"
+
       # # 배포용 쉘 스크립트 파일 전송
       # - name: Copy deploy.sh to remote server
       #   uses: appleboy/scp-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,7 @@ jobs:
             cd "$DIR"
             cd backend
             nohup yarn start &
+            disown
             exit
           EOF
       # # 배포용 쉘 스크립트 파일 전송

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,0 @@
-DIR="/home/root/app/octodocs"
-cd "$DIR"
-cd backend
-nohup yarn start &

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,37 +1,4 @@
-#!/bin/bash
-
-# 작업 디렉토리 경로
-DIR="/home/root/app/autodocs"
-
-# 디렉토리 확인
-if [ -d "$DIR" ]; then
-    echo "$DIR 디렉토리가 존재합니다. 최신 버전으로 업데이트 중..."
-    cd "$DIR"
-    git pull
-else
-    echo "$DIR 디렉토리가 존재하지 않습니다. 클론 중..."
-    git clone https://github.com/boostcampwm-2024/web15-OctoDocs.git "$DIR"
-    cd "$DIR"
-fi
-
-# backend 디렉토리로 이동
+DIR="/home/root/app/octodocs"
+cd "$DIR"
 cd backend
-
-# 기존 프로세스 확인 및 종료
-echo "기존 프로세스 확인 중..."
-EXISTING_PID=$(lsof -ti :3000) # 여기서 포트 번호는 필요에 따라 조정
-
-if [ -n "$EXISTING_PID" ]; then
-    echo "기존 프로세스(PID: $EXISTING_PID) 종료 중..."
-    kill -9 "$EXISTING_PID"
-    echo "기존 프로세스가 종료되었습니다."
-else
-    echo "실행 중인 프로세스가 없습니다."
-fi
-
-# 의존성 설치 및 애플리케이션 시작
-echo "의존성 설치 중..."
-yarn install
-
-echo "애플리케이션 시작 중..."
 nohup yarn start &


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #143 

## 📂 작업 내용

기존에는 최신 코드 받아오고 프로세스 실행하는 과정이 쉘 스크립트 파일로 이루어져 그 과정이 기록되지 않았습니다.

만약 쉘 스크립트 파일 실행이 실패하더라도 workflow는 성공한 것으로 나와서 결과 확인이 어려웠습니다.

그래서 sh 파일을 서버로 보내서 실행하는 것이 아니라 ssh 명령어를 통해 직접 원격 서버 명령어를 실행하도록 구현했습니다.

즉 directory 생성, git pull, 기존 프로세스 종료의 과정이 로깅됩니다.

하지만 그 후 마지막에 yarn start로 서버를 킬 때는 백그라운드로 실행되기 때문에 이 과정은 로깅되지 않습니다.


<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- sh 파일 전송 제거
- ssh 명령어 사용

## 📑 참고 자료 & 스크린샷 (선택)

**로깅 과정**
![image](https://github.com/user-attachments/assets/73d78570-930c-4828-b0bf-8291c5557841)


**아쉽게도 서버 실행은 로깅되지 않습니다.**
![image](https://github.com/user-attachments/assets/d5c966a6-a669-48dc-bf84-ed31f96d7a76)

