### PR TITLE
에디터에 패널 open/close 기능 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
 import Sidebar from "./components/sidebar";
 import HoverTrigger from "./components/HoverTrigger";
 import EditorView from "./components/EditorView";
@@ -11,7 +10,7 @@ const queryClient = new QueryClient();
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="h-screen bg-white">
+      <div className="fixed inset-0 bg-white">
         <SideWrapper side="right">
           <EditorView />
         </SideWrapper>

--- a/frontend/src/components/layout/EditorLayout.tsx
+++ b/frontend/src/components/layout/EditorLayout.tsx
@@ -1,11 +1,31 @@
+import { PanelRightClose, PanelLeftClose } from "lucide-react";
+import usePageStore from "@/store/usePageStore";
+
 interface EditorLayoutProps {
   children: React.ReactNode;
 }
 
-export default function EditorLayout({ children }: EditorLayoutProps) {
+const EditorLayout = ({ children }: EditorLayoutProps) => {
+  const { isPanelOpen, togglePanel } = usePageStore();
+
   return (
-    <div className="relative h-[720px] w-[520px] overflow-auto border-muted bg-background bg-white sm:rounded-lg sm:border sm:shadow-lg">
-      {children}
+    <div
+      className={`absolute right-0 h-[720px] w-[520px] transform rounded-bl-lg rounded-br-lg rounded-tr-lg border bg-white shadow-lg transition-transform duration-100 ease-in-out ${isPanelOpen ? "translate-x-0" : "translate-x-full"}`}
+    >
+      <div className="h-full overflow-auto">{children}</div>
+
+      <button
+        onClick={togglePanel}
+        className="absolute -left-8 top-0 z-50 flex h-8 w-8 !cursor-pointer items-center justify-center rounded-l border-b border-l border-t border-[#e0e6ee] bg-[#f5f5f5]"
+      >
+        {isPanelOpen ? (
+          <PanelRightClose className="h-4 w-4" />
+        ) : (
+          <PanelLeftClose className="h-4 w-4" />
+        )}
+      </button>
     </div>
   );
-}
+};
+
+export default EditorLayout;

--- a/frontend/src/components/layout/SideWrapper.tsx
+++ b/frontend/src/components/layout/SideWrapper.tsx
@@ -13,5 +13,5 @@ type SideWrapperProps = {
 };
 
 export default function SideWrapper({ side, children }: SideWrapperProps) {
-  return <div className={`absolute z-10 ${sideStyle[side]} `}>{children}</div>;
+  return <div className={`absolute z-50 ${sideStyle[side]} `}>{children}</div>;
 }

--- a/frontend/src/store/usePageStore.ts
+++ b/frontend/src/store/usePageStore.ts
@@ -2,12 +2,25 @@ import { create } from "zustand";
 
 interface PageStore {
   currentPage: number | null;
+  isPanelOpen: boolean;
   setCurrentPage: (currentPage: number | null) => void;
+  togglePanel: () => void;
+  setIsPanelOpen: (isOpen: boolean) => void;
 }
 
 const usePageStore = create<PageStore>((set) => ({
   currentPage: null,
-  setCurrentPage: (currentPage: number | null) => set({ currentPage }),
+  isPanelOpen: true,
+  setCurrentPage: (currentPage: number | null) =>
+    set((state) => ({
+      currentPage,
+      isPanelOpen:
+        currentPage === state.currentPage
+          ? !state.isPanelOpen
+          : currentPage !== null,
+    })),
+  togglePanel: () => set((state) => ({ isPanelOpen: !state.isPanelOpen })),
+  setIsPanelOpen: (isPanelOpen: boolean) => set({ isPanelOpen }),
 }));
 
 export default usePageStore;


### PR DESCRIPTION
## 🔖 연관된 이슈
- closes #165 
## 📂 작업 내용
- `usePageStore`에 `isPanelOpen` 추가
- 같은 페이지를 선택 시, 패널이 열려있었다면 닫히게, 닫혀 있었다면 열리게 구현
- `<Sidebar />` 컴포넌트가 패널 버튼을 가리지 않게 `z-index` 수정
- 패널이 닫혔을 때 전체 화면에 스크롤바가 생기는 이슈, 아래의 element에 접근 못하게 하는 이슈 수정
## 📑 참고 자료 & 스크린샷 (선택)
https://github.com/user-attachments/assets/c0dcb9fa-da48-472e-a705-8b524d9b1215

