### PR TITLE
페이지 생성 시, 생성된 페이지 ID로 에디터 열기

### DIFF
--- a/frontend/src/api/page.ts
+++ b/frontend/src/api/page.ts
@@ -30,6 +30,11 @@ export interface PagesResponse {
   pages: Omit<Page, "content">[];
 }
 
+interface CreatePageResponse {
+  message: string;
+  pageId: number;
+}
+
 export const getPage = async (id: number) => {
   const url = `/page/${id}`;
 
@@ -47,7 +52,7 @@ export const getPages = async () => {
 export const createPage = async (pageData: CreatePageRequest) => {
   const url = `/page`;
 
-  const res = await Post<null, CreatePageRequest>(url, pageData);
+  const res = await Post<CreatePageResponse, CreatePageRequest>(url, pageData);
   return res.data;
 };
 

--- a/frontend/src/components/sidebar/Tools.tsx
+++ b/frontend/src/components/sidebar/Tools.tsx
@@ -18,21 +18,22 @@ export default function Tools() {
     <Button
       className="flex flex-row items-center gap-1 rounded-sm px-2 py-1 font-medium hover:bg-neutral-100"
       onClick={() => {
-        createMutation.mutate({
-          title: "제목 없음",
-          content: {
-            type: "doc",
-            content: [
-              {
-                type: "paragraph",
-                content: [{ type: "text", text: "" }],
-              },
-            ],
-          },
-          x: 0,
-          y: 0,
-        });
-        setCurrentPage(pages[pages.length - 1].id);
+        createMutation
+          .mutateAsync({
+            title: "제목 없음",
+            content: {
+              type: "doc",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "" }],
+                },
+              ],
+            },
+            x: 0,
+            y: 0,
+          })
+          .then((res) => setCurrentPage(res.pageId));
       }}
     >
       <div>


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

- closes #167 

## 📂 작업 내용

페이지 생성 후, response로 받은 pageId로 에디터를 엽니다!
(mutate 후에 response로 pageId를 받아서 setCurrentPage를 설정합니다.)

## 📑 참고 자료 & 스크린샷 (선택)

https://github.com/user-attachments/assets/64629109-7b7c-4d1c-a69c-fe1ea2d1c1bb


