### PR TITLE
첫 렌더링 시 pages 쿼리 중복 요청 수정

### DIFF
--- a/frontend/src/components/canvas/index.tsx
+++ b/frontend/src/components/canvas/index.tsx
@@ -74,14 +74,23 @@ function Flow({ className }: CanvasProps) {
     const initialNodes = Array.from(nodesMap.values()) as Node[];
     setNodes(initialNodes);
 
+    let isInitialSync = true;
+
     nodesMap.observe((event) => {
+      if (isInitialSync) {
+        isInitialSync = false;
+        return;
+      }
+
       event.changes.keys.forEach((change, key) => {
         const nodeId = key;
         if (change.action === "add" || change.action === "update") {
           const updatedNode = nodesMap.get(nodeId) as Node;
 
           if (change.action === "add") {
-            queryClient.invalidateQueries({ queryKey: ["pages"] });
+            if (!existingPageIds.current.has(nodeId)) {
+              queryClient.invalidateQueries({ queryKey: ["pages"] });
+            }
           }
 
           setNodes((nds) => {

--- a/frontend/src/components/canvas/index.tsx
+++ b/frontend/src/components/canvas/index.tsx
@@ -88,9 +88,7 @@ function Flow({ className }: CanvasProps) {
           const updatedNode = nodesMap.get(nodeId) as Node;
 
           if (change.action === "add") {
-            if (!existingPageIds.current.has(nodeId)) {
-              queryClient.invalidateQueries({ queryKey: ["pages"] });
-            }
+            queryClient.invalidateQueries({ queryKey: ["pages"] });
           }
 
           setNodes((nds) => {


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- fixes #171 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- 첫 렌더링 시에는 `Y.Doc` 이벤트 `observe` 하지 않게 수정

## 📑 참고 자료 & 스크린샷 (선택)

![스크린샷 2024-11-15 오후 7 34 53](https://github.com/user-attachments/assets/93097d00-ef12-45c8-8bae-fc4d7d664993)

## 📢 리뷰 요구사항 (선택)

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
**설명**
-  첫 렌더일 때는 `observe` 하지 않게 수정 (그러지 않으면 처음에 `pages`를 가져와서 `nodesMap`에 하나씩 넣을 때 모두 변경 이벤트로 받아들여서 `invalidate` 합니다.)