### PR TITLE
에디터 블록 drag handle이 예상과 다른 곳에 위치하는 문제 수정

### DIFF
--- a/frontend/src/components/layout/EditorLayout.tsx
+++ b/frontend/src/components/layout/EditorLayout.tsx
@@ -10,7 +10,9 @@ const EditorLayout = ({ children }: EditorLayoutProps) => {
 
   return (
     <div
-      className={`absolute right-0 h-[720px] w-[520px] transform rounded-bl-lg rounded-br-lg rounded-tr-lg border bg-white shadow-lg transition-transform duration-100 ease-in-out ${isPanelOpen ? "translate-x-0" : "translate-x-full"}`}
+      className={`absolute right-0 h-[720px] w-[520px] rounded-bl-lg rounded-br-lg rounded-tr-lg border bg-white shadow-lg transition-transform duration-100 ease-in-out ${
+        isPanelOpen ? "transform-none" : "translate-x-full"
+      }`}
     >
       <div className="h-full overflow-auto">{children}</div>
 


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #177 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- `translate-x-0` 때문에 stacking context가 생성, `position: fixed`인 `<dragHandle />`이 이에 영향을 받는 문제를 `translate-none` 으로 변경해서 수정.

## 📑 참고 자료 & 스크린샷 (선택)


<img width="1185" alt="스크린샷 2024-11-17 오전 11 08 11" src="https://github.com/user-attachments/assets/3a7d6595-4553-404e-a5a0-8e1a018cff47">


## 📢 리뷰 요구사항 (선택)

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

> **`transform`**:  If the property has a value different from none, a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) will be created. In that case, the element will act as a [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block) for any position: fixed; or position: absolute; elements that it contains. (https://developer.mozilla.org/en-US/docs/Web/CSS/transform)

