### PR TITLE
가장 가까운 핸들에 연결, 노드 간 1개의 엣지만 가능하게 수정

### DIFF
--- a/apps/frontend/src/lib/getHandlePosition.ts
+++ b/apps/frontend/src/lib/getHandlePosition.ts
@@ -1,0 +1,28 @@
+import { Position, type Node } from "@xyflow/react";
+export function getHandlePosition(node: Node, handleId: Position) {
+  const nodeElement = document.querySelector(`[data-id="${node.id}"]`);
+  const nodeRect = nodeElement!.getBoundingClientRect();
+  const nodeWidth = nodeRect.width;
+  const nodeHeight = nodeRect.height;
+
+  const positions = {
+    [Position.Left]: {
+      x: node.position.x,
+      y: node.position.y + nodeHeight / 2,
+    },
+    [Position.Right]: {
+      x: node.position.x + nodeWidth,
+      y: node.position.y + nodeHeight / 2,
+    },
+    [Position.Top]: {
+      x: node.position.x + nodeWidth / 2,
+      y: node.position.y,
+    },
+    [Position.Bottom]: {
+      x: node.position.x + nodeWidth / 2,
+      y: node.position.y + nodeHeight,
+    },
+  };
+
+  return positions[handleId];
+}


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- closes #200  

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- 움직일 때, 가장 가까운 엣지로 변경
- 가장 가까운 핸들에 연결
- 노드 간 1개의 엣지만 가능하게 수정

## 📑 참고 자료 & 스크린샷 (선택)



https://github.com/user-attachments/assets/f958857b-f3b2-4bc4-a626-a5f0c054555a




## 📢 리뷰 요구사항 (선택)

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

- 기본적으로 `data-id`가 달려있더라구요..! 그래서 거기서 `getBoundingClientRect()`을 했습니다. 노드 `width`, `height`를 그대로 쓰는 것도 생각해봤는데 나중에 노드 크기가 다 다르면 안될 것 같아서요. 사실 `ref`로 가져올 수 있으면 제일 좋긴 할텐데 방법을 못찾아서.. 
- 로직 자체가 너무 코딩테스트 같아서.. 리팩토링을 해야되긴 할텐데.. 이게 ydoc이랑 얽혀 있다보니까 hook으로 분리하는게 쉽지 않네요..