### PR TITLE
Y.Doc의 node에 isHolding property 추가

### DIFF
--- a/apps/frontend/src/components/canvas/index.tsx
+++ b/apps/frontend/src/components/canvas/index.tsx
@@ -21,7 +21,6 @@ import "@xyflow/react/dist/style.css";
 import { usePages } from "@/hooks/usePages";
 import { NoteNode } from "./NoteNode";
 import * as Y from "yjs";
-// import { WebsocketProvider } from "y-websocket";
 import { SocketIOProvider } from "y-socket.io";
 import { cn } from "@/lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
@@ -33,6 +32,10 @@ import { CollaborativeCursors } from "../CursorView";
 import { getHandlePosition } from "@/lib/getHandlePosition";
 
 const proOptions = { hideAttribution: true };
+
+interface YNode extends Node {
+  isHolding: boolean;
+}
 
 interface CanvasProps {
   className?: string;
@@ -54,6 +57,7 @@ function Flow({ className }: CanvasProps) {
 
   const provider = useRef<SocketIOProvider>();
   const existingPageIds = useRef(new Set<string>());
+  const holdingNodeRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!pages) return;
@@ -93,7 +97,15 @@ function Flow({ className }: CanvasProps) {
     const nodesMap = ydoc.getMap("nodes");
     const edgesMap = ydoc.getMap("edges");
 
-    const initialNodes = Array.from(nodesMap.values()) as Node[];
+    const yNodes = Array.from(nodesMap.values()) as YNode[];
+
+    const initialNodes = yNodes.map((yNode) => {
+      const nodeEntries = Object.entries(yNode).filter(
+        ([key]) => key !== "isHolding",
+      );
+      return Object.fromEntries(nodeEntries) as Node;
+    });
+
     setNodes(initialNodes);
 
     let isInitialSync = true;
@@ -107,7 +119,12 @@ function Flow({ className }: CanvasProps) {
       event.changes.keys.forEach((change, key) => {
         const nodeId = key;
         if (change.action === "add" || change.action === "update") {
-          const updatedNode = nodesMap.get(nodeId) as Node;
+          const updatedYNode = nodesMap.get(nodeId) as YNode;
+          console.log(updatedYNode);
+          const updatedNodeEntries = Object.entries(updatedYNode).filter(
+            ([key]) => key !== "isHolding",
+          );
+          const updatedNode = Object.fromEntries(updatedNodeEntries) as Node;
 
           if (change.action === "add") {
             queryClient.invalidateQueries({ queryKey: ["pages"] });
@@ -157,9 +174,9 @@ function Flow({ className }: CanvasProps) {
 
     pages.forEach((page) => {
       const pageId = page.id.toString();
-      const existingNode = nodesMap.get(pageId) as Node | undefined;
+      const existingNode = nodesMap.get(pageId) as YNode | undefined;
 
-      const newNode = {
+      const newNode: YNode = {
         id: pageId,
         type: "note",
         data: { title: page.title, id: page.id },
@@ -168,6 +185,7 @@ function Flow({ className }: CanvasProps) {
           y: Math.random() * 500,
         },
         selected: false,
+        isHolding: false,
       };
 
       nodesMap.set(pageId, newNode);
@@ -185,12 +203,13 @@ function Flow({ className }: CanvasProps) {
         if (change.type === "position" && change.position) {
           const node = nodes.find((n) => n.id === change.id);
           if (node) {
-            const updatedNode = {
+            const updatedYNode: YNode = {
               ...node,
               position: change.position,
               selected: false,
+              isHolding: holdingNodeRef.current === change.id,
             };
-            nodesMap.set(change.id, updatedNode);
+            nodesMap.set(change.id, updatedYNode);
 
             edges.forEach((edge) => {
               if (edge.source === change.id || edge.target === change.id) {
@@ -330,6 +349,25 @@ function Flow({ className }: CanvasProps) {
     [setEdges, edges, nodes, ydoc],
   );
 
+  const onNodeDragStart = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      holdingNodeRef.current = node.id;
+    },
+    [],
+  );
+
+  const onNodeDragStop = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      if (ydoc) {
+        const nodesMap = ydoc.getMap("nodes");
+        const yNode = nodesMap.get(node.id) as YNode | undefined;
+        if (yNode) {
+          nodesMap.set(node.id, { ...yNode, isHolding: false });
+        }
+      }
+    },
+    [ydoc],
+  );
   const nodeTypes = useMemo(() => ({ note: NoteNode }), []);
 
   return (
@@ -341,6 +379,8 @@ function Flow({ className }: CanvasProps) {
         onEdgesChange={handleEdgesChange}
         onMouseLeave={handleMouseLeave}
         onNodeDrag={handleNodeDrag}
+        onNodeDragStart={onNodeDragStart}
+        onNodeDragStop={onNodeDragStop}
         onConnect={onConnect}
         proOptions={proOptions}
         nodeTypes={nodeTypes}

--- a/apps/frontend/src/components/canvas/index.tsx
+++ b/apps/frontend/src/components/canvas/index.tsx
@@ -120,7 +120,6 @@ function Flow({ className }: CanvasProps) {
         const nodeId = key;
         if (change.action === "add" || change.action === "update") {
           const updatedYNode = nodesMap.get(nodeId) as YNode;
-          console.log(updatedYNode);
           const updatedNodeEntries = Object.entries(updatedYNode).filter(
             ([key]) => key !== "isHolding",
           );


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- closes #207 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- Y.Doc의 `node`에 `isHolding` property 추가.
- `dragStop` 시, `false`로 설정해서 보내기.

## 📑 참고 자료 & 스크린샷 (선택)

<img width="1278" alt="스크린샷 2024-11-19 오후 6 20 35" src="https://github.com/user-attachments/assets/a8cf08ed-7fb2-4ca9-874a-129c7146f019">

## 📢 리뷰 요구사항 (선택)

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

- `isHolding`입니다. 어떻게 고쳐도 마지막에 `false`로 2번을 보내네요.. 사실 디바운싱이 목적이었으니까 일단은 이것으로 충분하지 않을까 싶긴 합니다..
- `Object.entries()` 와 `filter()`를 사용한 부분이 있는데, eslint rule과 싸워서 빌드 성공하기 위한 엄청난 사투가 있었습니다.. 😇 원래 원했던 것 : `const initialNodes = yNodes.map(({ isHolding, ...node }) => node);`