### PR TITLE
유저를 관리하기 위한 웹소켓 Room 추가

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
 import Sidebar from "./components/sidebar";
 import HoverTrigger from "./components/HoverTrigger";
 import EditorView from "./components/EditorView";
@@ -6,9 +7,13 @@ import SideWrapper from "./components/layout/SideWrapper";
 import Canvas from "./components/canvas";
 import ScrollWrapper from "./components/layout/ScrollWrapper";
 
+import { useSyncedUsers } from "./hooks/useSyncedUsers";
+
 const queryClient = new QueryClient();
 
 function App() {
+  useSyncedUsers();
+
   return (
     <QueryClientProvider client={queryClient}>
       <div className="fixed inset-0 bg-white">

--- a/apps/frontend/src/components/CursorView.tsx
+++ b/apps/frontend/src/components/CursorView.tsx
@@ -3,6 +3,7 @@ import { useReactFlow } from "@xyflow/react";
 import { type AwarenessState } from "@/hooks/useCursor";
 import Cursor from "./cursor";
 import { useMemo } from "react";
+import useUserStore from "@/store/useUserStore";
 
 interface CollaborativeCursorsProps {
   cursors: Map<number, AwarenessState>;
@@ -11,8 +12,15 @@ interface CollaborativeCursorsProps {
 export function CollaborativeCursors({ cursors }: CollaborativeCursorsProps) {
   const { flowToScreenPosition } = useReactFlow();
 
+  const { currentUser } = useUserStore();
+
   const validCursors = useMemo(
-    () => Array.from(cursors.values()).filter((cursor) => cursor.cursor),
+    () =>
+      Array.from(cursors.values()).filter(
+        (cursor) =>
+          cursor.cursor &&
+          (cursor.clientId as unknown as string) !== currentUser.clientId,
+      ),
     [cursors],
   );
 
@@ -26,6 +34,7 @@ export function CollaborativeCursors({ cursors }: CollaborativeCursorsProps) {
             y: cursor.cursor!.y,
           })}
           color={cursor.color}
+          clientId={cursor.clientId.toString()}
         />
       ))}
     </Panel>

--- a/apps/frontend/src/components/EditorView.tsx
+++ b/apps/frontend/src/components/EditorView.tsx
@@ -5,11 +5,14 @@ import * as Y from "yjs";
 import { SocketIOProvider } from "y-socket.io";
 
 import Editor from "./editor";
-import usePageStore from "@/store/usePageStore";
-import { usePage, useUpdatePage } from "@/hooks/usePages";
 import EditorLayout from "./layout/EditorLayout";
 import EditorTitle from "./editor/EditorTitle";
 import SaveStatus from "./editor/ui/SaveStatus";
+import ActiveUser from "./commons/activeUser";
+
+import usePageStore from "@/store/usePageStore";
+import useUserStore from "@/store/useUserStore";
+import { usePage, useUpdatePage } from "@/hooks/usePages";
 
 export default function EditorView() {
   const { currentPage } = usePageStore();
@@ -17,6 +20,7 @@ export default function EditorView() {
   const [saveStatus, setSaveStatus] = useState<"saved" | "unsaved">("saved");
   const [ydoc, setYDoc] = useState<Y.Doc | null>(null);
   const [provider, setProvider] = useState<SocketIOProvider | null>(null);
+  const { users } = useUserStore();
 
   useEffect(() => {
     if (!currentPage) return;
@@ -87,6 +91,12 @@ export default function EditorView() {
         key={currentPage}
         currentPage={currentPage}
         pageContent={pageContent}
+      />
+      <ActiveUser
+        className="px-12 py-4"
+        users={users.filter(
+          (user) => user.currentPageId === currentPage.toString(),
+        )}
       />
       <Editor
         key={ydoc.guid}

--- a/apps/frontend/src/components/canvas/NoteNode.tsx
+++ b/apps/frontend/src/components/canvas/NoteNode.tsx
@@ -1,11 +1,14 @@
 import { Handle, NodeProps, Position, type Node } from "@xyflow/react";
 import usePageStore from "@/store/usePageStore";
+import useUserStore from "@/store/useUserStore";
+import { cn } from "@/lib/utils";
 
 export type NoteNodeData = { title: string; id: number };
 export type NoteNodeType = Node<NoteNodeData, "note">;
 
 export function NoteNode({ data }: NodeProps<NoteNodeType>) {
   const { setCurrentPage } = usePageStore();
+  const { users } = useUserStore();
 
   const handleNodeClick = () => {
     const id = data.id;
@@ -46,6 +49,24 @@ export function NoteNode({ data }: NodeProps<NoteNodeType>) {
         isConnectable={true}
       />
       {data.title}
+      <div className="flex justify-end gap-2">
+        {users
+          .filter((user) => user.currentPageId === data.id.toString())
+          .map((user) => (
+            <div
+              style={{ backgroundColor: user.color }}
+              className={cn("group relative h-5 w-5 rounded-full")}
+              key={user.clientId}
+            >
+              <div
+                style={{ backgroundColor: user.color }}
+                className="absolute left-2 z-10 hidden px-2 text-sm group-hover:flex"
+              >
+                {user.clientId}
+              </div>
+            </div>
+          ))}
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/components/canvas/NoteNode.tsx
+++ b/apps/frontend/src/components/canvas/NoteNode.tsx
@@ -1,7 +1,9 @@
 import { Handle, NodeProps, Position, type Node } from "@xyflow/react";
+
+import ActiveUser from "../commons/activeUser";
+
 import usePageStore from "@/store/usePageStore";
 import useUserStore from "@/store/useUserStore";
-import { cn } from "@/lib/utils";
 
 export type NoteNodeData = { title: string; id: number };
 export type NoteNodeType = Node<NoteNodeData, "note">;
@@ -49,24 +51,12 @@ export function NoteNode({ data }: NodeProps<NoteNodeType>) {
         isConnectable={true}
       />
       {data.title}
-      <div className="flex justify-end gap-2">
-        {users
-          .filter((user) => user.currentPageId === data.id.toString())
-          .map((user) => (
-            <div
-              style={{ backgroundColor: user.color }}
-              className={cn("group relative h-5 w-5 rounded-full")}
-              key={user.clientId}
-            >
-              <div
-                style={{ backgroundColor: user.color }}
-                className="absolute left-2 z-10 hidden px-2 text-sm group-hover:flex"
-              >
-                {user.clientId}
-              </div>
-            </div>
-          ))}
-      </div>
+      <ActiveUser
+        className="justify-end"
+        users={users.filter(
+          (user) => user.currentPageId === data.id.toString(),
+        )}
+      />
     </div>
   );
 }

--- a/apps/frontend/src/components/commons/activeUser/index.tsx
+++ b/apps/frontend/src/components/commons/activeUser/index.tsx
@@ -1,0 +1,28 @@
+import { User } from "@/store/useUserStore";
+import { cn } from "@/lib/utils";
+
+interface ActiveUserProps {
+  users: User[];
+  className?: string;
+}
+
+export default function ActiveUser({ users, className }: ActiveUserProps) {
+  return (
+    <div className={cn("flex gap-2", className)}>
+      {users.map((user) => (
+        <div
+          style={{ backgroundColor: user.color }}
+          className={cn("group relative h-5 w-5 rounded-full")}
+          key={user.clientId}
+        >
+          <div
+            style={{ backgroundColor: user.color }}
+            className="absolute left-2 z-10 hidden px-2 text-sm group-hover:flex"
+          >
+            {user.clientId}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/cursor/index.tsx
+++ b/apps/frontend/src/components/cursor/index.tsx
@@ -7,10 +7,15 @@ export interface Coors {
 
 interface CursorProps {
   coors: Coors;
+  clientId: string;
   color?: string;
 }
 
-export default function Cursor({ coors, color = "#ffb8b9" }: CursorProps) {
+export default function Cursor({
+  coors,
+  color = "#ffb8b9",
+  clientId,
+}: CursorProps) {
   const { x, y } = coors;
 
   return (
@@ -35,6 +40,9 @@ export default function Cursor({ coors, color = "#ffb8b9" }: CursorProps) {
           strokeWidth="4"
         />
       </svg>
+      <p className="absolute px-1" style={{ backgroundColor: color }}>
+        {clientId}
+      </p>
     </motion.div>
   );
 }

--- a/apps/frontend/src/hooks/useCursor.ts
+++ b/apps/frontend/src/hooks/useCursor.ts
@@ -2,6 +2,7 @@ import { useReactFlow, type XYPosition } from "@xyflow/react";
 import * as Y from "yjs";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { SocketIOProvider } from "y-socket.io";
+import useUserStore from "@/store/useUserStore";
 
 const CURSOR_COLORS = [
   "#7d7b94",
@@ -33,10 +34,7 @@ export function useCollaborativeCursors({
   const [cursors, setCursors] = useState<Map<number, AwarenessState>>(
     new Map(),
   );
-  const clientId = useRef<number | null>(null);
-  const userColor = useRef(
-    CURSOR_COLORS[Math.floor(Math.random() * CURSOR_COLORS.length)],
-  );
+  const { currentUser } = useUserStore();
 
   useEffect(() => {
     const wsProvider = new SocketIOProvider(
@@ -55,21 +53,18 @@ export function useCollaborativeCursors({
     );
 
     provider.current = wsProvider;
-    clientId.current = wsProvider.awareness.clientID;
 
     wsProvider.awareness.setLocalState({
       cursor: null,
-      color: userColor.current,
-      clientId: wsProvider.awareness.clientID,
+      color: currentUser.color,
+      clientId: currentUser.clientId,
     });
 
     wsProvider.awareness.on("change", () => {
       const states = new Map(
         Array.from(
           wsProvider.awareness.getStates() as Map<number, AwarenessState>,
-        ).filter(
-          ([key, state]) => key !== clientId.current && state.cursor !== null,
-        ),
+        ).filter(([key, state]) => state.cursor !== null),
       );
       setCursors(states);
     });
@@ -90,8 +85,8 @@ export function useCollaborativeCursors({
 
       provider.current.awareness.setLocalState({
         cursor,
-        color: userColor.current,
-        clientId: provider.current.awareness.clientID,
+        color: currentUser.color,
+        clientId: currentUser.clientId,
       });
     },
     [flowInstance],

--- a/apps/frontend/src/hooks/useCursor.ts
+++ b/apps/frontend/src/hooks/useCursor.ts
@@ -4,16 +4,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { SocketIOProvider } from "y-socket.io";
 import useUserStore from "@/store/useUserStore";
 
-const CURSOR_COLORS = [
-  "#7d7b94",
-  "#41c76d",
-  "#f86e7e",
-  "#f6b8b8",
-  "#f7d353",
-  "#3b5bf7",
-  "#59cbf7",
-] as const;
-
 export interface AwarenessState {
   cursor: XYPosition | null;
   color: string;
@@ -64,7 +54,7 @@ export function useCollaborativeCursors({
       const states = new Map(
         Array.from(
           wsProvider.awareness.getStates() as Map<number, AwarenessState>,
-        ).filter(([key, state]) => state.cursor !== null),
+        ).filter(([, state]) => state.cursor !== null),
       );
       setCursors(states);
     });

--- a/apps/frontend/src/hooks/useSyncedUsers.ts
+++ b/apps/frontend/src/hooks/useSyncedUsers.ts
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+
+import usePageStore from "@/store/usePageStore";
+import useUserStore, { User } from "@/store/useUserStore";
+
+export const useSyncedUsers = () => {
+  const { currentPage } = usePageStore();
+  const { provider, currentUser, setCurrentUser, setUsers } = useUserStore();
+
+  const updateUsersFromAwareness = () => {
+    const values = Array.from(
+      provider.awareness.getStates().values(),
+    ) as User[];
+    setUsers(values);
+  };
+
+  const getLocalStorageUser = (): User | null => {
+    const userData = localStorage.getItem("currentUser");
+    return userData ? JSON.parse(userData) : null;
+  };
+
+  useEffect(() => {
+    if (currentPage === null) return;
+
+    const updatedUser: User = {
+      ...currentUser,
+      currentPageId: currentPage.toString(),
+    };
+
+    setCurrentUser(updatedUser);
+    provider.awareness.setLocalState(updatedUser);
+  }, [currentPage]);
+
+  useEffect(() => {
+    const localStorageUser = getLocalStorageUser();
+
+    if (!localStorageUser) {
+      localStorage.setItem("currentUser", JSON.stringify(currentUser));
+    } else {
+      setCurrentUser(localStorageUser);
+      provider.awareness.setLocalState(localStorageUser);
+    }
+
+    updateUsersFromAwareness();
+
+    provider.awareness.on("change", updateUsersFromAwareness);
+
+    return () => {
+      provider.awareness.off("change", updateUsersFromAwareness);
+    };
+  }, []);
+};

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -4,3 +4,23 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function getRandomColor() {
+  const COLORS = [
+    "#7d7b94",
+    "#41c76d",
+    "#f86e7e",
+    "#f6b8b8",
+    "#f7d353",
+    "#3b5bf7",
+    "#59cbf7",
+  ] as const;
+
+  return COLORS[Math.floor(Math.random() * COLORS.length)];
+}
+
+export function getRandomHexString(length = 10) {
+  return [...Array(length)]
+    .map(() => Math.floor(Math.random() * 16).toString(16))
+    .join("");
+}

--- a/apps/frontend/src/store/useUserStore.ts
+++ b/apps/frontend/src/store/useUserStore.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+import * as Y from "yjs";
+import { SocketIOProvider } from "y-socket.io";
+
+import { getRandomColor, getRandomHexString } from "@/lib/utils";
+
+export interface User {
+  clientId: string;
+  color: string;
+  currentPageId: string | null;
+}
+
+interface UserStore {
+  provider: SocketIOProvider;
+  users: User[];
+  currentUser: User;
+  setUsers: (users: User[]) => void;
+  setCurrentUser: (user: User) => void;
+}
+
+const useUserStore = create<UserStore>((set) => ({
+  provider: new SocketIOProvider(
+    import.meta.env.VITE_WS_URL,
+    `users`,
+    new Y.Doc(),
+    {
+      autoConnect: true,
+      disableBc: false,
+    },
+    {
+      reconnectionDelayMax: 10000,
+      timeout: 5000,
+      transports: ["websocket", "polling"],
+    },
+  ),
+  users: [],
+  currentUser: {
+    clientId: getRandomHexString(10),
+    color: getRandomColor(),
+    currentPageId: null,
+  },
+  setUsers: (users: User[]) => set({ users }),
+  setCurrentUser: (user: User) => set({ currentUser: user }),
+}));
+
+export default useUserStore;


### PR DESCRIPTION

## 🔖 연관된 이슈

- closes #206

## 📂 작업 내용

- Client 룸 생성하기
- 유저 식별을 위한 랜덤 색상 및 clientId 생성 (로컬스토리지 이용)
- 에디터 접속 인원을 노드와 에디터에 보여주기

## 📑 참고 자료 & 스크린샷 (선택)


https://github.com/user-attachments/assets/1902239d-17ec-414c-81d1-eb2bb73dcb2e


## 📢 리뷰 요구사항 (선택)

일단 디자인은 최대한 간단하게 했습니다. (추후 수정을 위해)
궁금한 게 하나 있는데, 자신의 접속 현황은 표시를 안하는 게 자연스러울까요??

### 추후 수정해야 할 사항
1. 에디터(content)에서 클라이언트를 일관되게 보여주기 (에디터 마다 다른 웹 소켓 Room에 접속해서)
2. 중복 탭 문제 -> 클라이언트 id가 같은 접속 현황이 여러 개 보여지게 됨
3. 이미 접속중인 `clientId` 가 있으면 이전 연결을 끊고, 새로운 연결을 해야 할 거 같습니다! (새로고침하면 flow-room에 다시 연결돼서 컴포넌트 `key` 문제가 생깁니다.

