### PR TITLE
document name 파싱 이슈 해결

### DIFF
--- a/apps/backend/src/yjs/yjs.service.ts
+++ b/apps/backend/src/yjs/yjs.service.ts
@@ -91,7 +91,7 @@ export class YjsService
 
       // document name이 flow-room이라면 모든 노드들을 볼 수 있는 화면입니다.
       // 노드를 클릭해 페이지를 열었을 때만 해당 페이지 값을 가져와서 초기 데이터로 세팅해줍니다.
-      if (customDoc.name !== 'flow-room') {
+      if (customDoc.name?.startsWith('document-')) {
         const pageId = parseInt(customDoc.name.split('-')[1]);
         const findPage = await this.pageService.findPageById(pageId);
 


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #223 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- document 파싱 이슈 해결
document-1 에서 숫자를 파싱하지 못 하는 이슈였습니다.

```
if (customDoc.name !== 'flow-room')
```

기존에는 flow-room과 document-숫자 밖에 없어서 문제가 없었지만 users가 추가되면서 발생한 이슈입니다.

"document-"로 시작할 때만 파싱하도록 변경했습니다.
```
      if (customDoc.name?.startsWith('document-')) {

```

