### PR TITLE
커서 이름 표시 바 스타일링

### DIFF
--- a/apps/frontend/src/components/cursor/index.tsx
+++ b/apps/frontend/src/components/cursor/index.tsx
@@ -20,7 +20,7 @@ export default function Cursor({
 
   return (
     <motion.div
-      className="pointer-events-none absolute left-0 top-0 z-50 h-6 w-6"
+      className="pointer-events-none absolute left-0 top-0 z-50"
       initial={{ x, y }}
       animate={{ x, y }}
       transition={{
@@ -32,17 +32,27 @@ export default function Cursor({
         restSpeed: 0.01,
       }}
     >
-      <svg viewBox="0 0 94 99" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path
-          d="M2.40255 5.31234C1.90848 3.6645 3.58743 2.20312 5.15139 2.91972L90.0649 41.8264C91.7151 42.5825 91.5858 44.9688 89.8637 45.5422L54.7989 57.2186C53.3211 57.7107 52.0926 58.7582 51.3731 60.1397L33.0019 95.4124C32.1726 97.0047 29.8279 96.7826 29.3124 95.063L2.40255 5.31234Z"
-          fill={color}
-          stroke="black"
-          strokeWidth="4"
-        />
-      </svg>
-      <p className="absolute px-1" style={{ backgroundColor: color }}>
-        {clientId}
-      </p>
+      <div className="relative">
+        <svg
+          className="h-6 w-6"
+          viewBox="0 0 94 99"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2.40255 5.31234C1.90848 3.6645 3.58743 2.20312 5.15139 2.91972L90.0649 41.8264C91.7151 42.5825 91.5858 44.9688 89.8637 45.5422L54.7989 57.2186C53.3211 57.7107 52.0926 58.7582 51.3731 60.1397L33.0019 95.4124C32.1726 97.0047 29.8279 96.7826 29.3124 95.063L2.40255 5.31234Z"
+            fill={color}
+            stroke="black"
+            strokeWidth="4"
+          />
+        </svg>
+        <div
+          className="absolute left-6 top-6 max-w-28 truncate rounded-lg border-[1px] border-black px-2 py-1 text-center text-sm font-semibold shadow-sm"
+          style={{ backgroundColor: color }}
+        >
+          {clientId}
+        </div>
+      </div>
     </motion.div>
   );
 }


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #229 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- 커서 이름 표시 바 스타일링

## 📑 참고 자료 & 스크린샷 (선택)

<img width="825" alt="스크린샷 2024-11-21 오전 7 34 52" src="https://github.com/user-attachments/assets/2fae893b-2191-43f4-9942-e8ab93887104">

<img width="825" alt="스크린샷 2024-11-21 오전 7 35 00" src="https://github.com/user-attachments/assets/7780383a-6d6c-4904-ac87-5c3fe0da071f">

## 📢 리뷰 요구사항 (선택)

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

- 이모지 1개 + 번호 + 이름까지 들어갈만큼으로 `max-w`을 설정해두었습니다.
- 고민되는 지점 : 어두운 색상의 경우 텍스트가 흰색이어야 할 것 같아서 사용자가 설정할 수 있는 컬러셋을 만들어두는게 좋을 것 같습니다. 