### PR TITLE
Bug be #235

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -2,7 +2,7 @@ name: Create Directory on Remote Server
 on:
   push:
     branches:
-      - main
+      - develop
 
 jobs:
   env:
@@ -16,15 +16,15 @@ jobs:
       # .env 파일 생성 후 붙여넣기
       - name: Create .env file
         run: |
-          echo "${{secrets.PRODUCTION_ENV}}" > ./.env
+          echo "${{secrets.DEVELOPMENT_ENV}}" > ./.env
 
       # sh 실행
       - name: Connect to Remote Server and Run Commands
         env:
-          REMOTE_HOST: ${{ secrets.REMOTE_PROD_IP }}
+          REMOTE_HOST: ${{ secrets.REMOTE_DEV_IP }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
-          BRANCH_NAME: "main"
+          BRANCH_NAME: "develop"
         run: |
           mkdir ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/id_rsa
@@ -36,16 +36,16 @@ jobs:
             if [ -d "$DIR" ]; then
                 echo "$DIR 디렉토리가 존재합니다. 최신 버전으로 업데이트 중..."
                 cd "$DIR"
-                git switch -c main
-                git pull origin main
+                git switch -c develop
+                git pull origin develop
 
 
             else
                 echo "$DIR 디렉토리가 존재하지 않습니다. 클론 중..."
                 git clone https://github.com/boostcampwm-2024/web15-OctoDocs.git "$DIR"
                 cd "$DIR"
-                git switch -c main
-                git pull origin main
+                git switch -c develop
+                git pull origin develop
             fi
 
 
@@ -81,7 +81,7 @@ jobs:
       - name: Copy .env to remote server
         uses: appleboy/scp-action@master
         with:
-          host: ${{ secrets.REMOTE_PROD_IP }}
+          host: ${{ secrets.REMOTE_DEV_IP }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           source: ./.env
@@ -89,7 +89,7 @@ jobs:
       - name: Copy .env to remote server
         uses: appleboy/scp-action@master
         with:
-          host: ${{ secrets.REMOTE_PROD_IP }}
+          host: ${{ secrets.REMOTE_DEV_IP }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           source: ./.env
@@ -98,7 +98,7 @@ jobs:
       # yarn start
       - name: yarn start
         env:
-          REMOTE_HOST: ${{ secrets.REMOTE_PROD_IP }}
+          REMOTE_HOST: ${{ secrets.REMOTE_DEV_IP }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
         run: |

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -69,5 +69,6 @@
     "typescript-eslint": "^8.11.0",
     "vite": "^5.4.10",
     "vite-tsconfig-paths": "^5.1.0"
-  }
+  },
+  "homepage": "./"
 }


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #235 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- 프론트엔드 package.json에 homepage 추가
- 개발, 상용 배포 환경 분리

로컬 개발 환경과 원격 환경의 코드가 동일함에도 정적 파일에서 오류가 발생했습니다.

기본적으로 리액트를 빌드할 때 루트 디렉토리를 기준으로 한다고 합니다. 

homepage로 이 디렉토리를 바꿔주어 에러를 해결했습니다.
