### PR TITLE
document: 아키텍처 object storage를 VPC 바깥으로 이동

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 v.241115
 
-![octodocs-architecture](https://github.com/user-attachments/assets/1051f137-9369-437d-9e00-12b487095c9c)
+![octodocs-architecture](https://github.com/user-attachments/assets/18461bff-25ad-439a-ada0-73f4ea37e4d7)
 
 
 ## 🧸 팀원 소개


### PR DESCRIPTION


## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- 시스템 아키텍처 이미지 변경

실수로 Object Storage를 VPC 안으로 넣어서 바깥으로 뺐습니다!!

## 📑 참고 자료 & 스크린샷 (선택)
![octodocs-architecture](https://github.com/user-attachments/assets/18461bff-25ad-439a-ada0-73f4ea37e4d7)