### PR TITLE
Popover 공용 컴포넌트 구현

### DIFF
--- a/apps/frontend/src/components/commons/popover/Content.tsx
+++ b/apps/frontend/src/components/commons/popover/Content.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { usePopover } from "@/hooks/usePopover";
 import { cn } from "@/lib/utils";
 import { getPosition } from "@/lib/getPopoverPosition";
@@ -13,7 +13,7 @@ export function Content({ children, className }: ContentProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState({ top: 0, left: 0 });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (open && triggerRef.current && contentRef.current) {
       const triggerRect = triggerRef.current.getBoundingClientRect();
       const contentRect = contentRef.current.getBoundingClientRect();

--- a/apps/frontend/src/components/commons/popover/Content.tsx
+++ b/apps/frontend/src/components/commons/popover/Content.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+import { usePopover } from "@/hooks/usePopover";
+import { cn } from "@/lib/utils";
+import { getPosition } from "@/lib/getPopoverPosition";
+
+interface ContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Content({ children, className }: ContentProps) {
+  const { open, setOpen, triggerRef, placement, offset } = usePopover();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+
+  useEffect(() => {
+    if (open && triggerRef.current && contentRef.current) {
+      const triggerRect = triggerRef.current.getBoundingClientRect();
+      const contentRect = contentRef.current.getBoundingClientRect();
+      const newPosition = getPosition(
+        triggerRect,
+        contentRect,
+        placement,
+        offset,
+      );
+      setPosition(newPosition);
+    }
+  }, [open, placement, offset, triggerRef]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        !contentRef.current?.contains(e.target as Node) &&
+        !triggerRef.current?.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [setOpen, triggerRef]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={contentRef}
+      className={cn("fixed z-50", className)}
+      style={{
+        top: `${position.top}px`,
+        left: `${position.left}px`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/commons/popover/Trigger.tsx
+++ b/apps/frontend/src/components/commons/popover/Trigger.tsx
@@ -1,0 +1,15 @@
+import { usePopover } from "@/hooks/usePopover";
+
+interface TriggerProps {
+  children: React.ReactNode;
+}
+
+export function Trigger({ children }: TriggerProps) {
+  const { open, setOpen, triggerRef } = usePopover();
+
+  return (
+    <div ref={triggerRef} onClick={() => setOpen(!open)}>
+      {children}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/commons/popover/index.tsx
+++ b/apps/frontend/src/components/commons/popover/index.tsx
@@ -12,7 +12,7 @@ interface PopoverProps {
 function Popover({
   children,
   placement = "bottom",
-  offset = { x: 0, y: 8 },
+  offset = { x: 0, y: 0 },
 }: PopoverProps) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLDivElement>(null);

--- a/apps/frontend/src/components/commons/popover/index.tsx
+++ b/apps/frontend/src/components/commons/popover/index.tsx
@@ -1,0 +1,43 @@
+import { useRef, useState } from "react";
+import { Content } from "./Content";
+import { Trigger } from "./Trigger";
+import { PopoverContext, Placement, Offset } from "@/hooks/usePopover";
+
+interface PopoverProps {
+  children: React.ReactNode;
+  placement?: Placement;
+  offset?: Partial<Offset>;
+}
+
+function Popover({
+  children,
+  placement = "bottom",
+  offset = { x: 0, y: 8 },
+}: PopoverProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  const fullOffset: Offset = {
+    x: offset.x ?? 0,
+    y: offset.y ?? 0,
+  };
+
+  return (
+    <PopoverContext.Provider
+      value={{
+        open,
+        setOpen,
+        triggerRef,
+        placement,
+        offset: fullOffset,
+      }}
+    >
+      {children}
+    </PopoverContext.Provider>
+  );
+}
+
+Popover.Trigger = Trigger;
+Popover.Content = Content;
+
+export { Popover };

--- a/apps/frontend/src/hooks/usePopover.ts
+++ b/apps/frontend/src/hooks/usePopover.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext } from "react";
+
+export type Placement = "top" | "right" | "bottom" | "left";
+
+export interface Offset {
+  x: number;
+  y: number;
+}
+
+export interface PopoverContextType {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  triggerRef: React.RefObject<HTMLDivElement>;
+  placement: Placement;
+  offset: Offset;
+}
+
+export const PopoverContext = createContext<PopoverContextType | null>(null);
+
+export function usePopover() {
+  const context = useContext(PopoverContext);
+  if (!context) {
+    throw new Error("Popover 컨텍스트를 찾을 수 없음.");
+  }
+  return context;
+}

--- a/apps/frontend/src/lib/getPopoverPosition.ts
+++ b/apps/frontend/src/lib/getPopoverPosition.ts
@@ -1,0 +1,69 @@
+import { Placement, Offset } from "@/hooks/usePopover";
+
+export interface Position {
+  top: number;
+  left: number;
+}
+
+interface PositionConfig {
+  triggerRect: DOMRect;
+  contentRect: DOMRect;
+  offset: Offset;
+}
+
+const getTopPosition = ({
+  triggerRect,
+  contentRect,
+  offset,
+}: PositionConfig): Position => ({
+  top: triggerRect.top - contentRect.height - offset.y,
+  left:
+    triggerRect.left + (triggerRect.width - contentRect.width) / 2 + offset.x,
+});
+
+const getRightPosition = ({
+  triggerRect,
+  contentRect,
+  offset,
+}: PositionConfig): Position => ({
+  top:
+    triggerRect.top + (triggerRect.height - contentRect.height) / 2 + offset.y,
+  left: triggerRect.right + offset.x,
+});
+
+const getBottomPosition = ({
+  triggerRect,
+  contentRect,
+  offset,
+}: PositionConfig): Position => ({
+  top: triggerRect.bottom + offset.y,
+  left:
+    triggerRect.left + (triggerRect.width - contentRect.width) / 2 + offset.x,
+});
+
+const getLeftPosition = ({
+  triggerRect,
+  contentRect,
+  offset,
+}: PositionConfig): Position => ({
+  top:
+    triggerRect.top + (triggerRect.height - contentRect.height) / 2 + offset.y,
+  left: triggerRect.left - contentRect.width - offset.x,
+});
+
+const positionMap: Record<Placement, (config: PositionConfig) => Position> = {
+  top: getTopPosition,
+  right: getRightPosition,
+  bottom: getBottomPosition,
+  left: getLeftPosition,
+};
+
+export function getPosition(
+  triggerRect: DOMRect,
+  contentRect: DOMRect,
+  placement: Placement,
+  offset: Offset,
+): Position {
+  const config = { triggerRect, contentRect, offset };
+  return positionMap[placement](config);
+}


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #266 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- `<Popover.Trigger />`, `<Popover.Content />`
- 컨텍스트를 위한 `usePopover()`
- `Trigger`, `Content`의 rect로 위치 계산, 중앙에 위치시키기 위한 `getPosition()`

## 📑 참고 자료 & 스크린샷 (선택)


https://github.com/user-attachments/assets/867097f3-77a5-4a3d-b669-3e71fd165bd2



## 📢 리뷰 요구사항 (선택)

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
- 캔버스에서 클릭 이벤트를 삼켜버려서 캔버스 클릭으로는 닫히지 않습니다..
- 앞으로 다른 기능에도 영향을 줄 수 있을 것 같아서 따로 이슈를 만들어서 해결해야 할 것 같아요.
- `offset?: Partial<Offset>;` 로 `x` 또는 `y`만 넣어줘도 사용할 수 있게 해뒀습니다.
