### PR TITLE
워크스페이스 구조 추가, 업데이트 

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -34,6 +34,7 @@
     "@nestjs/swagger": "^8.0.5",
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.4.8",
+    "@theinternetfolks/snowflake": "^1.3.0",
     "@types/multer": "^1.4.12",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -10,6 +10,8 @@ import { Page } from './page/page.entity';
 import { Edge } from './edge/edge.entity';
 import { Node } from './node/node.entity';
 import { User } from './user/user.entity';
+import { Workspace } from './workspace/workspace.entity';
+import { Role } from './role/role.entity';
 import { YjsModule } from './yjs/yjs.module';
 import * as path from 'path';
 import { ServeStaticModule } from '@nestjs/serve-static';
@@ -34,7 +36,7 @@ import { RoleModule } from './role/role.module';
       useFactory: (configService: ConfigService) => ({
         type: 'sqlite',
         database: configService.get('DB_NAME'),
-        entities: [Node, Page, Edge, User],
+        entities: [Node, Page, Edge, User, Workspace, Role],
         logging: true,
         synchronize: true,
       }),

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { ServeStaticModule } from '@nestjs/serve-static';
 import { UploadModule } from './upload/upload.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
+import { WorkspaceModule } from './workspace/workspace.module';
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { UserModule } from './user/user.module';
     UploadModule,
     AuthModule,
     UserModule,
+    WorkspaceModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -17,6 +17,7 @@ import { UploadModule } from './upload/upload.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { WorkspaceModule } from './workspace/workspace.module';
+import { RoleModule } from './role/role.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { WorkspaceModule } from './workspace/workspace.module';
     AuthModule,
     UserModule,
     WorkspaceModule,
+    RoleModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -21,4 +21,8 @@ export class AuthService {
     const user = this.userRepository.create(dto);
     return this.userRepository.save(user);
   }
+
+  async findUserBySnowflakeId(snowflakeId: string): Promise<User | null> {
+    return await this.userRepository.findOneBy({ snowflakeId });
+  }
 }

--- a/apps/backend/src/auth/strategies/kakao.strategy.ts
+++ b/apps/backend/src/auth/strategies/kakao.strategy.ts
@@ -26,6 +26,6 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
     if (!user) {
       user = await this.authService.signUp(createUserDto);
     }
-    return user; // req.user로 반환
+    return { snowflakeId: user.snowflakeId };
   }
 }

--- a/apps/backend/src/auth/strategies/kakao.strategy.ts
+++ b/apps/backend/src/auth/strategies/kakao.strategy.ts
@@ -26,6 +26,6 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
     if (!user) {
       user = await this.authService.signUp(createUserDto);
     }
-    return { snowflakeId: user.snowflakeId };
+    return user; // req.user로 반환
   }
 }

--- a/apps/backend/src/auth/strategies/naver.strategy.ts
+++ b/apps/backend/src/auth/strategies/naver.strategy.ts
@@ -26,6 +26,6 @@ export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
     if (!user) {
       user = await this.authService.signUp(createUserDto);
     }
-    return user; // req.user로 반환
+    return { snowflakeId: user.snowflakeId };
   }
 }

--- a/apps/backend/src/auth/strategies/naver.strategy.ts
+++ b/apps/backend/src/auth/strategies/naver.strategy.ts
@@ -26,6 +26,6 @@ export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
     if (!user) {
       user = await this.authService.signUp(createUserDto);
     }
-    return { snowflakeId: user.snowflakeId };
+    return user;
   }
 }

--- a/apps/backend/src/edge/edge.controller.spec.ts
+++ b/apps/backend/src/edge/edge.controller.spec.ts
@@ -83,6 +83,7 @@ describe('EdgeController', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
       const node4 = {
         id: 4,
@@ -92,6 +93,7 @@ describe('EdgeController', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
       const node5 = {
         id: 5,
@@ -101,6 +103,7 @@ describe('EdgeController', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
 
       const expectedEdges = [

--- a/apps/backend/src/edge/edge.entity.ts
+++ b/apps/backend/src/edge/edge.entity.ts
@@ -7,6 +7,7 @@ import {
   JoinColumn,
 } from 'typeorm';
 import { Node } from '../node/node.entity';
+import { Workspace } from '../workspace/workspace.entity';
 
 @Entity()
 export class Edge {
@@ -20,6 +21,12 @@ export class Edge {
   @ManyToOne(() => Node, (node) => node.incomingEdges, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'to_node_id' })
   toNode: Node;
+
+  @ManyToOne(() => Workspace, (workspace) => workspace.edges, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'workspace_id' })
+  workspace: Workspace;
 
   // @Column({ nullable: true })
   // type: string;

--- a/apps/backend/src/edge/edge.module.ts
+++ b/apps/backend/src/edge/edge.module.ts
@@ -4,12 +4,12 @@ import { EdgeController } from './edge.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Edge } from './edge.entity';
 import { EdgeRepository } from './edge.repository';
-import { NodeModule } from 'src/node/node.module';
+import { NodeModule } from '../node/node.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Edge]), forwardRef(() => NodeModule)],
   controllers: [EdgeController],
   providers: [EdgeService, EdgeRepository],
-  exports: [EdgeService]
+  exports: [EdgeService],
 })
 export class EdgeModule {}

--- a/apps/backend/src/edge/edge.repository.ts
+++ b/apps/backend/src/edge/edge.repository.ts
@@ -8,4 +8,11 @@ export class EdgeRepository extends Repository<Edge> {
   constructor(@InjectDataSource() private dataSource: DataSource) {
     super(Edge, dataSource.createEntityManager());
   }
+
+  async findEdgesByWorkspace(workspaceId: number): Promise<Edge[]> {
+    return this.find({
+      where: { workspace: { id: workspaceId } },
+      relations: ['fromNode', 'toNode'],
+    });
+  }
 }

--- a/apps/backend/src/edge/edge.service.spec.ts
+++ b/apps/backend/src/edge/edge.service.spec.ts
@@ -56,6 +56,7 @@ describe('EdgeService', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
       const toNode = {
         id: 5,
@@ -65,6 +66,7 @@ describe('EdgeService', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
       const edge = {
         id: 1,
@@ -118,6 +120,7 @@ describe('EdgeService', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
       const node4 = {
         id: 4,
@@ -127,6 +130,7 @@ describe('EdgeService', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
       const node5 = {
         id: 5,
@@ -136,6 +140,7 @@ describe('EdgeService', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
       const node7 = {
         id: 7,
@@ -145,6 +150,7 @@ describe('EdgeService', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
 
       const expectedEdgeList = [

--- a/apps/backend/src/node/node.entity.ts
+++ b/apps/backend/src/node/node.entity.ts
@@ -4,11 +4,13 @@ import {
   PrimaryGeneratedColumn,
   Column,
   OneToOne,
+  ManyToOne,
   OneToMany,
   JoinColumn,
 } from 'typeorm';
 import { Page } from '../page/page.entity';
 import { Edge } from '../edge/edge.entity';
+import { Workspace } from '../workspace/workspace.entity';
 
 @Entity()
 export class Node {
@@ -33,4 +35,10 @@ export class Node {
 
   @OneToMany(() => Edge, (edge) => edge.toNode)
   incomingEdges: Edge[];
+
+  @ManyToOne(() => Workspace, (workspace) => workspace.nodes, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'workspace_id' })
+  workspace: Workspace;
 }

--- a/apps/backend/src/node/node.repository.ts
+++ b/apps/backend/src/node/node.repository.ts
@@ -12,4 +12,8 @@ export class NodeRepository extends Repository<Node> {
   async findById(id: number): Promise<Node | null> {
     return await this.findOneBy({ id });
   }
+
+  async findNodesByWorkspace(workspaceId: number): Promise<Node[]> {
+    return this.find({ where: { workspace: { id: workspaceId } } });
+  }
 }

--- a/apps/backend/src/node/node.service.spec.ts
+++ b/apps/backend/src/node/node.service.spec.ts
@@ -59,6 +59,7 @@ describe('NodeService', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
       const page = { id: 1, title: 'Test Page', content: null } as Page;
 
@@ -173,6 +174,7 @@ describe('NodeService', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       } as Node;
       jest.spyOn(nodeRepository, 'findOne').mockResolvedValue(node);
 

--- a/apps/backend/src/page/page.controller.spec.ts
+++ b/apps/backend/src/page/page.controller.spec.ts
@@ -52,6 +52,7 @@ describe('PageController', () => {
       const newDate = new Date();
       jest.spyOn(pageService, 'createPage').mockResolvedValue({
         id: 1,
+        snowflakeId: 'generated-snowflake-id-page',
         title: 'New Page',
         content: {} as JSON,
         createdAt: newDate,
@@ -136,6 +137,7 @@ describe('PageController', () => {
     it('id에 해당하는 페이지의 상세 정보를 반환한다.', async () => {
       const expectedPage: Page = {
         id: 1,
+        snowflakeId: 'generated-snowflake-id-page',
         title: 'title',
         content: {} as JSON,
         node: null,

--- a/apps/backend/src/page/page.controller.spec.ts
+++ b/apps/backend/src/page/page.controller.spec.ts
@@ -59,6 +59,7 @@ describe('PageController', () => {
         version: 1,
         node: null,
         emoji: null,
+        workspace: null,
       });
       const result = await controller.createPage(dto);
 
@@ -143,6 +144,7 @@ describe('PageController', () => {
         updatedAt: new Date(),
         version: 1,
         emoji: null,
+        workspace: null,
       };
 
       jest.spyOn(pageService, 'findPageById').mockResolvedValue(expectedPage);

--- a/apps/backend/src/page/page.controller.spec.ts
+++ b/apps/backend/src/page/page.controller.spec.ts
@@ -52,7 +52,6 @@ describe('PageController', () => {
       const newDate = new Date();
       jest.spyOn(pageService, 'createPage').mockResolvedValue({
         id: 1,
-        snowflakeId: 'generated-snowflake-id-page',
         title: 'New Page',
         content: {} as JSON,
         createdAt: newDate,
@@ -137,7 +136,6 @@ describe('PageController', () => {
     it('id에 해당하는 페이지의 상세 정보를 반환한다.', async () => {
       const expectedPage: Page = {
         id: 1,
-        snowflakeId: 'generated-snowflake-id-page',
         title: 'title',
         content: {} as JSON,
         node: null,

--- a/apps/backend/src/page/page.entity.ts
+++ b/apps/backend/src/page/page.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   Entity,
   OneToOne,
+  ManyToOne,
   PrimaryGeneratedColumn,
   JoinColumn,
   CreateDateColumn,
@@ -9,6 +10,7 @@ import {
   VersionColumn,
 } from 'typeorm';
 import { Node } from '../node/node.entity';
+import { Workspace } from '../workspace/workspace.entity';
 
 @Entity()
 export class Page {
@@ -38,4 +40,10 @@ export class Page {
   })
   @JoinColumn()
   node: Node;
+
+  @ManyToOne(() => Workspace, (workspace) => workspace.pages, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'workspace_id' })
+  workspace: Workspace;
 }

--- a/apps/backend/src/page/page.entity.ts
+++ b/apps/backend/src/page/page.entity.ts
@@ -7,19 +7,13 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   VersionColumn,
-  Index,
 } from 'typeorm';
 import { Node } from '../node/node.entity';
-import { Snowflake } from '@theinternetfolks/snowflake';
 
 @Entity()
 export class Page {
   @PrimaryGeneratedColumn('increment')
   id: number;
-
-  @Column({ unique: true })
-  @Index()
-  snowflakeId: string = Snowflake.generate();
 
   @Column()
   title: string;

--- a/apps/backend/src/page/page.entity.ts
+++ b/apps/backend/src/page/page.entity.ts
@@ -7,13 +7,19 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   VersionColumn,
+  Index,
 } from 'typeorm';
 import { Node } from '../node/node.entity';
+import { Snowflake } from '@theinternetfolks/snowflake';
 
 @Entity()
 export class Page {
   @PrimaryGeneratedColumn('increment')
   id: number;
+
+  @Column({ unique: true })
+  @Index()
+  snowflakeId: string = Snowflake.generate();
 
   @Column()
   title: string;
@@ -32,13 +38,6 @@ export class Page {
 
   @Column({ nullable: true })
   emoji: string | null;
-
-  // TODO:추가적인 메타데이터 컬럼들(user 기능 추가할때)
-  // @Column('created_by')
-  // createdBy: string;
-
-  // @Column('updated_by')
-  // updatedBy: string;
 
   @OneToOne(() => Node, (node) => node.page, {
     onDelete: 'CASCADE',

--- a/apps/backend/src/page/page.repository.ts
+++ b/apps/backend/src/page/page.repository.ts
@@ -18,4 +18,8 @@ export class PageRepository extends Repository<Page> {
       },
     });
   }
+
+  async findPagesByWorkspace(workspaceId: number): Promise<Page[]> {
+    return this.find({ where: { workspace: { id: workspaceId } } });
+  }
 }

--- a/apps/backend/src/page/page.service.spec.ts
+++ b/apps/backend/src/page/page.service.spec.ts
@@ -69,6 +69,7 @@ describe('PageService', () => {
         version: 1,
         node: null,
         emoji: null,
+        workspace: null,
       };
 
       // 노드 엔티티
@@ -79,6 +80,7 @@ describe('PageService', () => {
         page: null,
         outgoingEdges: [],
         incomingEdges: [],
+        workspace: null,
       };
 
       // 레포지토리 모킹
@@ -134,6 +136,7 @@ describe('PageService', () => {
         updatedAt: originDate,
         version: 1,
         emoji: null,
+        workspace: null,
       };
       const newDate = new Date();
       const newPage: Page = {
@@ -145,6 +148,7 @@ describe('PageService', () => {
         updatedAt: newDate,
         version: 1,
         emoji: '📝',
+        workspace: null,
       };
 
       jest.spyOn(pageRepository, 'findOneBy').mockResolvedValue(originPage);
@@ -182,6 +186,7 @@ describe('PageService', () => {
         updatedAt: newDate,
         version: 1,
         emoji: null,
+        workspace: null,
       };
       jest.spyOn(pageRepository, 'findOneBy').mockResolvedValue(expectedPage);
 

--- a/apps/backend/src/page/page.service.spec.ts
+++ b/apps/backend/src/page/page.service.spec.ts
@@ -62,6 +62,7 @@ describe('PageService', () => {
       // 페이지 엔티티
       const newPage: Page = {
         id: 1,
+        snowflakeId: 'generated-snowflake-id-page',
         title: 'new page',
         content: {} as JSON,
         createdAt: newDate,
@@ -127,6 +128,7 @@ describe('PageService', () => {
       const originDate = new Date();
       const originPage: Page = {
         id: 1,
+        snowflakeId: 'generated-snowflake-id-page',
         title: 'origin title',
         content: {} as JSON,
         node: null,
@@ -138,6 +140,7 @@ describe('PageService', () => {
       const newDate = new Date();
       const newPage: Page = {
         id: 1,
+        snowflakeId: 'generated-snowflake-id-page',
         title: 'Updated Title',
         content: {} as JSON,
         node: null,
@@ -175,6 +178,7 @@ describe('PageService', () => {
       const newDate = new Date();
       const expectedPage: Page = {
         id: 1,
+        snowflakeId: 'generated-snowflake-id-page',
         title: 'title',
         content: {} as JSON,
         node: null,
@@ -204,16 +208,19 @@ describe('PageService', () => {
       const expectedPageList = [
         {
           id: 1,
+          snowflakeId: 'generated-snowflake-id-page-1',
           title: 'title1',
           node: null,
         },
         {
           id: 2,
+          snowflakeId: 'generated-snowflake-id-page-2',
           title: 'title2',
           node: null,
         },
         {
           id: 3,
+          snowflakeId: 'generated-snowflake-id-page-3',
           title: 'title3',
           node: null,
         },

--- a/apps/backend/src/page/page.service.spec.ts
+++ b/apps/backend/src/page/page.service.spec.ts
@@ -62,7 +62,6 @@ describe('PageService', () => {
       // 페이지 엔티티
       const newPage: Page = {
         id: 1,
-        snowflakeId: 'generated-snowflake-id-page',
         title: 'new page',
         content: {} as JSON,
         createdAt: newDate,
@@ -128,7 +127,6 @@ describe('PageService', () => {
       const originDate = new Date();
       const originPage: Page = {
         id: 1,
-        snowflakeId: 'generated-snowflake-id-page',
         title: 'origin title',
         content: {} as JSON,
         node: null,
@@ -140,7 +138,6 @@ describe('PageService', () => {
       const newDate = new Date();
       const newPage: Page = {
         id: 1,
-        snowflakeId: 'generated-snowflake-id-page',
         title: 'Updated Title',
         content: {} as JSON,
         node: null,
@@ -178,7 +175,6 @@ describe('PageService', () => {
       const newDate = new Date();
       const expectedPage: Page = {
         id: 1,
-        snowflakeId: 'generated-snowflake-id-page',
         title: 'title',
         content: {} as JSON,
         node: null,
@@ -208,19 +204,16 @@ describe('PageService', () => {
       const expectedPageList = [
         {
           id: 1,
-          snowflakeId: 'generated-snowflake-id-page-1',
           title: 'title1',
           node: null,
         },
         {
           id: 2,
-          snowflakeId: 'generated-snowflake-id-page-2',
           title: 'title2',
           node: null,
         },
         {
           id: 3,
-          snowflakeId: 'generated-snowflake-id-page-3',
           title: 'title3',
           node: null,
         },

--- a/apps/backend/src/role/role.controller.spec.ts
+++ b/apps/backend/src/role/role.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoleController } from './role.controller';
+
+describe('RoleController', () => {
+  let controller: RoleController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RoleController],
+    }).compile();
+
+    controller = module.get<RoleController>(RoleController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/role/role.controller.spec.ts
+++ b/apps/backend/src/role/role.controller.spec.ts
@@ -1,15 +1,24 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RoleController } from './role.controller';
+import { RoleService } from './role.service';
 
 describe('RoleController', () => {
   let controller: RoleController;
+  let roleService: RoleService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RoleController],
+      providers: [
+        {
+          provide: RoleService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<RoleController>(RoleController);
+    roleService = module.get<RoleService>(RoleService);
   });
 
   it('should be defined', () => {

--- a/apps/backend/src/role/role.controller.ts
+++ b/apps/backend/src/role/role.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { RoleService } from './role.service';
+
+@Controller('role')
+export class RoleController {
+  constructor(private readonly roleService: RoleService) {}
+}

--- a/apps/backend/src/role/role.entity.ts
+++ b/apps/backend/src/role/role.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  PrimaryColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { User } from '../user/user.entity';
+import { Workspace } from '../workspace/workspace.entity';
+
+@Entity()
+export class Role {
+  @PrimaryColumn()
+  workspaceId: number;
+
+  @PrimaryColumn()
+  userId: number;
+
+  @ManyToOne(() => Workspace, (workspace) => workspace.id, {
+    onDelete: 'CASCADE',
+  })
+  workspace: Workspace;
+
+  @ManyToOne(() => User, (user) => user.id, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column({ type: 'enum', enum: ['owner', 'guest'] })
+  role: 'owner' | 'guest';
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/backend/src/role/role.entity.ts
+++ b/apps/backend/src/role/role.entity.ts
@@ -24,8 +24,10 @@ export class Role {
   @ManyToOne(() => User, (user) => user.id, { onDelete: 'CASCADE' })
   user: User;
 
-  @Column({ type: 'enum', enum: ['owner', 'guest'] })
-  role: 'owner' | 'guest';
+  // 'owner' 또는 'guest'
+  // 저 중 하나로 제한 필요함 -> service에서 관리해야됨
+  @Column()
+  role: string;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/apps/backend/src/role/role.module.ts
+++ b/apps/backend/src/role/role.module.ts
@@ -1,0 +1,20 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { RoleService } from './role.service';
+import { RoleController } from './role.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Role } from './role.entity';
+import { RoleRepository } from './role.repository';
+import { UserModule } from '../user/user.module';
+import { WorkspaceModule } from '../workspace/workspace.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Role]),
+    forwardRef(() => UserModule),
+    forwardRef(() => WorkspaceModule),
+  ],
+  controllers: [RoleController],
+  providers: [RoleService, RoleRepository],
+  exports: [RoleService, RoleRepository],
+})
+export class RoleModule {}

--- a/apps/backend/src/role/role.repository.ts
+++ b/apps/backend/src/role/role.repository.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Role } from './role.entity';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+@Injectable()
+export class RoleRepository extends Repository<Role> {
+  constructor(@InjectDataSource() private dataSource: DataSource) {
+    super(Role, dataSource.createEntityManager());
+  }
+}

--- a/apps/backend/src/role/role.service.spec.ts
+++ b/apps/backend/src/role/role.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoleService } from './role.service';
+
+describe('RoleService', () => {
+  let service: RoleService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RoleService],
+    }).compile();
+
+    service = module.get<RoleService>(RoleService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/role/role.service.spec.ts
+++ b/apps/backend/src/role/role.service.spec.ts
@@ -1,15 +1,38 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RoleService } from './role.service';
+import { RoleRepository } from './role.repository';
+import { UserRepository } from '../user/user.repository';
+import { WorkspaceRepository } from '../workspace/workspace.repository';
 
 describe('RoleService', () => {
   let service: RoleService;
+  let userRepository: UserRepository;
+  let workspaceRepository: WorkspaceRepository;
+  let roleRepository: RoleRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RoleService],
+      providers: [
+        RoleService,
+        {
+          provide: RoleRepository,
+          useValue: {},
+        },
+        {
+          provide: UserRepository,
+          useValue: {},
+        },
+        {
+          provide: WorkspaceRepository,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<RoleService>(RoleService);
+    roleRepository = module.get<RoleRepository>(RoleRepository);
+    userRepository = module.get<UserRepository>(UserRepository);
+    workspaceRepository = module.get<WorkspaceRepository>(WorkspaceRepository);
   });
 
   it('should be defined', () => {

--- a/apps/backend/src/role/role.service.ts
+++ b/apps/backend/src/role/role.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { RoleRepository } from './role.repository';
+import { UserRepository } from '../user/user.repository';
+import { WorkspaceRepository } from '../workspace/workspace.repository';
+
+@Injectable()
+export class RoleService {
+  constructor(
+    private readonly roleRepository: RoleRepository,
+    private readonly workspaceRepository: WorkspaceRepository,
+    private readonly userRepository: UserRepository,
+  ) {}
+}

--- a/apps/backend/src/user/user.entity.ts
+++ b/apps/backend/src/user/user.entity.ts
@@ -4,12 +4,18 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  Index,
 } from 'typeorm';
+import { Snowflake } from '@theinternetfolks/snowflake';
 
 @Entity()
 export class User {
   @PrimaryGeneratedColumn('increment')
   id: number;
+
+  @Column({ unique: true })
+  @Index()
+  snowflakeId: string = Snowflake.generate();
 
   @Column({ unique: true })
   providerId: string; // 네이버/카카오 ID

--- a/apps/backend/src/workspace/workspace.controller.spec.ts
+++ b/apps/backend/src/workspace/workspace.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkspaceController } from './workspace.controller';
+
+describe('WorkspaceController', () => {
+  let controller: WorkspaceController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WorkspaceController],
+    }).compile();
+
+    controller = module.get<WorkspaceController>(WorkspaceController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/workspace/workspace.controller.spec.ts
+++ b/apps/backend/src/workspace/workspace.controller.spec.ts
@@ -1,15 +1,24 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WorkspaceController } from './workspace.controller';
+import { WorkspaceService } from './workspace.service';
 
 describe('WorkspaceController', () => {
   let controller: WorkspaceController;
+  let workspaceService: WorkspaceService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [WorkspaceController],
+      providers: [
+        {
+          provide: WorkspaceService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<WorkspaceController>(WorkspaceController);
+    workspaceService = module.get<WorkspaceService>(WorkspaceService);
   });
 
   it('should be defined', () => {

--- a/apps/backend/src/workspace/workspace.controller.ts
+++ b/apps/backend/src/workspace/workspace.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('workspace')
+export class WorkspaceController {}

--- a/apps/backend/src/workspace/workspace.controller.ts
+++ b/apps/backend/src/workspace/workspace.controller.ts
@@ -1,4 +1,7 @@
 import { Controller } from '@nestjs/common';
+import { WorkspaceService } from './workspace.service';
 
 @Controller('workspace')
-export class WorkspaceController {}
+export class WorkspaceController {
+  constructor(private readonly workspaceService: WorkspaceService) {}
+}

--- a/apps/backend/src/workspace/workspace.entity.ts
+++ b/apps/backend/src/workspace/workspace.entity.ts
@@ -5,9 +5,13 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
 } from 'typeorm';
 import { User } from '../user/user.entity';
 import { Snowflake } from '@theinternetfolks/snowflake';
+import { Edge } from '../edge/edge.entity';
+import { Page } from '../page/page.entity';
+import { Node } from '../node/node.entity';
 
 @Entity()
 export class Workspace {
@@ -37,4 +41,13 @@ export class Workspace {
 
   @Column({ nullable: true })
   thumbnailUrl: string;
+
+  @OneToMany(() => Edge, (edge) => edge.workspace)
+  edges: Edge[];
+
+  @OneToMany(() => Page, (page) => page.workspace)
+  pages: Page[];
+
+  @OneToMany(() => Node, (node) => node.workspace)
+  nodes: Node[];
 }

--- a/apps/backend/src/workspace/workspace.entity.ts
+++ b/apps/backend/src/workspace/workspace.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../user/user.entity';
+import { Snowflake } from '@theinternetfolks/snowflake';
+
+@Entity()
+export class Workspace {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  snowflakeId: string = Snowflake.generate();
+
+  @ManyToOne(() => User, { nullable: false })
+  owner: User;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column({ default: 'private' })
+  visibility: 'public' | 'private';
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @Column({ nullable: true })
+  thumbnailUrl: string;
+}

--- a/apps/backend/src/workspace/workspace.module.ts
+++ b/apps/backend/src/workspace/workspace.module.ts
@@ -11,7 +11,8 @@ import { UserModule } from '../user/user.module';
     TypeOrmModule.forFeature([Workspace]),
     forwardRef(() => UserModule),
   ],
+  controllers: [WorkspaceController],
   providers: [WorkspaceService, WorkspaceRepository],
-  controllers: [WorkspaceController, WorkspaceRepository],
+  exports: [WorkspaceService, WorkspaceRepository],
 })
 export class WorkspaceModule {}

--- a/apps/backend/src/workspace/workspace.module.ts
+++ b/apps/backend/src/workspace/workspace.module.ts
@@ -1,0 +1,17 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { WorkspaceService } from './workspace.service';
+import { WorkspaceController } from './workspace.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Workspace } from './workspace.entity';
+import { WorkspaceRepository } from './workspace.repository';
+import { UserModule } from '../user/user.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Workspace]),
+    forwardRef(() => UserModule),
+  ],
+  providers: [WorkspaceService, WorkspaceRepository],
+  controllers: [WorkspaceController, WorkspaceRepository],
+})
+export class WorkspaceModule {}

--- a/apps/backend/src/workspace/workspace.repository.ts
+++ b/apps/backend/src/workspace/workspace.repository.ts
@@ -1,0 +1,1 @@
+export class WorkspaceRepository {}

--- a/apps/backend/src/workspace/workspace.repository.ts
+++ b/apps/backend/src/workspace/workspace.repository.ts
@@ -1,1 +1,11 @@
-export class WorkspaceRepository {}
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Workspace } from './workspace.entity';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+@Injectable()
+export class WorkspaceRepository extends Repository<Workspace> {
+  constructor(@InjectDataSource() private dataSource: DataSource) {
+    super(Workspace, dataSource.createEntityManager());
+  }
+}

--- a/apps/backend/src/workspace/workspace.service.spec.ts
+++ b/apps/backend/src/workspace/workspace.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkspaceService } from './workspace.service';
+
+describe('WorkspaceService', () => {
+  let service: WorkspaceService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WorkspaceService],
+    }).compile();
+
+    service = module.get<WorkspaceService>(WorkspaceService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/workspace/workspace.service.spec.ts
+++ b/apps/backend/src/workspace/workspace.service.spec.ts
@@ -1,15 +1,31 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WorkspaceService } from './workspace.service';
+import { WorkspaceRepository } from './workspace.repository';
+import { UserRepository } from '../user/user.repository';
 
 describe('WorkspaceService', () => {
   let service: WorkspaceService;
+  let userRepository: UserRepository;
+  let workspaceRepository: WorkspaceRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [WorkspaceService],
+      providers: [
+        WorkspaceService,
+        {
+          provide: WorkspaceRepository,
+          useValue: {},
+        },
+        {
+          provide: UserRepository,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<WorkspaceService>(WorkspaceService);
+    workspaceRepository = module.get<WorkspaceRepository>(WorkspaceRepository);
+    userRepository = module.get<UserRepository>(UserRepository);
   });
 
   it('should be defined', () => {

--- a/apps/backend/src/workspace/workspace.service.ts
+++ b/apps/backend/src/workspace/workspace.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class WorkspaceService {}

--- a/apps/backend/src/workspace/workspace.service.ts
+++ b/apps/backend/src/workspace/workspace.service.ts
@@ -1,4 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { UserRepository } from '../user/user.repository';
+import { WorkspaceRepository } from './workspace.repository';
+// import { Workspace } from './workspace.entity';
 
 @Injectable()
-export class WorkspaceService {}
+export class WorkspaceService {
+  constructor(
+    private readonly workspaceRepository: WorkspaceRepository,
+    private readonly userRepository: UserRepository,
+  ) {}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,6 +2766,11 @@
   dependencies:
     "@tanstack/query-core" "5.60.6"
 
+"@theinternetfolks/snowflake@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@theinternetfolks/snowflake/-/snowflake-1.3.0.tgz#da26407eba4a0639d23e6ea08136e66270ee0e03"
+  integrity sha512-/5fjyE+JIa95Lm1uDJ9fx52W7/ZHBVvKo5GbpR+swpchbriLzVgFAIUOVwLsscnUTBixyQ+JsEh5pJQM/zKNzQ==
+
 "@tiptap/core@^2.1.7", "@tiptap/core@^2.9.1":
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/@tiptap/core/-/core-2.9.1.tgz#ceed211a9ecfe25a94e0e0863936169990e75aee"
@@ -9604,7 +9609,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9636,7 +9650,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10535,7 +10556,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10548,6 +10569,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- closes #204

## 📂 작업 내용

- [x] workspace 관련 구조 추가, 수정
  - [x] 외부에 노출될 api의 경우 대체키: snowflakeId 추가 
- [x] Workspace Entity 정의 (primary key, 대체키: snowflakeId, owner, private/public 여부)
- [x] Role Entity 정의 (userId, workspaceId - 복합해서 primarykey, role)
- [x] 기존 DB에 워크스페이스 칼럼 추가: page, node, edge에 모두 추가

## 📑 참고 자료 & 스크린샷 (선택)

## 📢 리뷰 요구사항 (선택)
- 일단 기존에 있는 user, 새로만은 workspace는 외부에서 api 들어올 일이 확실히 있을 것 같아 대체키 snowflakeId가 자동생성되도록 부여해놨습니다
- 그런데 page는 잘 모르겠어요... 변경사항이 많아서 일단은 대체키 넣지 않았습니다 의견 받습니다
- Role, Workspace DB (Entity) 설계 괜찮은지 검토 부탁드립니다 

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
