### PR TITLE
로컬 개발환경 재구성 및 https & wss 적용

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,3 @@
-# env
-.env
-.env*
-*.local
-.turbo
-.crt
-.key
-!Dockerfile.local
 
 # compiled output
 */dist

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -44,6 +44,7 @@
     "passport-kakao": "^1.0.1",
     "passport-naver": "^1.0.6",
     "path": "^0.12.7",
+    "pg": "^8.13.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -24,13 +24,17 @@ import { UserModule } from './user/user.module';
     }),
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: path.join(__dirname, '..', '.env'), // * nest 디렉터리 기준
+      envFilePath: path.join(__dirname, '..', '..', '..', '.env'), // * nest 디렉터리 기준
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
-        type: 'sqlite',
+        type: 'postgres',
+        host: configService.get('DB_HOST'),
+        port: configService.get('DB_PORT'),
+        username: configService.get('DB_USER'),
+        password: configService.get('DB_PASSWORD'),
         database: configService.get('DB_NAME'),
         entities: [Node, Page, Edge, User],
         logging: true,

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -1,0 +1,59 @@
+version: "3.8"
+
+services:
+    postgres:
+        image: postgres:16-alpine
+        environment:
+            POSTGRES_USER: ${DB_USER}
+            POSTGRES_PASSWORD: ${DB_PASSWORD}
+            POSTGRES_DB: ${DB_NAME}
+        volumes:
+            - postgres_data:/var/lib/postgresql/data
+        networks:
+            - backend
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+
+    backend:
+        build:
+            context: .
+            dockerfile: ./services/backend/Dockerfile.local
+        image: backend:latest
+        env_file:
+            - .env
+        depends_on:
+            postgres:
+                condition: service_healthy
+        networks:
+            - backend
+            - frontend
+
+    nginx:
+        build:
+            context: .
+            dockerfile: ./services/nginx/Dockerfile.local
+        ports:
+            - "80:80"
+            - "443:443"
+        depends_on:
+            - backend
+        networks:
+            - frontend
+        volumes:
+            - type: bind
+              source: ./services/nginx/ssl
+              target: /etc/nginx/ssl
+              bind:
+                  create_host_path: true
+                  propagation: rprivate
+
+networks:
+    backend:
+        internal: true
+    frontend:
+
+volumes:
+    postgres_data:

--- a/package.json
+++ b/package.json
@@ -1,23 +1,28 @@
 {
-  "name": "octodocs",
-  "version": "1.0.0",
-  "main": "index.js",
-  "repository": "https://github.com/boostcampwm-2024/web15-OctoDocs.git",
-  "author": "ez <105545215+ezcolin2@users.noreply.github.com>",
-  "license": "MIT",
-  "scripts": {
-    "dev": "turbo run dev",
-    "build": "turbo run build",
-    "start": "node apps/backend/dist/main.js",
-    "lint": "turbo run lint",
-    "test": "turbo run test"
-  },
-  "dependencies": {
-    "turbo": "^2.3.0"
-  },
-  "private": true,
-  "workspaces": [
-    "apps/*"
-  ],
-  "packageManager": "yarn@1.22.22"
+    "name": "octodocs",
+    "version": "1.0.0",
+    "main": "index.js",
+    "repository": "https://github.com/boostcampwm-2024/web15-OctoDocs.git",
+    "author": "ez <105545215+ezcolin2@users.noreply.github.com>",
+    "license": "MIT",
+    "scripts": {
+        "dev": "turbo run dev",
+        "build": "turbo run build",
+        "start": "node apps/backend/dist/main.js",
+        "lint": "turbo run lint",
+        "test": "turbo run test",
+        "docker:dev": "docker compose -f compose.local.yml up",
+        "docker:dev:down": "docker compose -f compose.local.yml down",
+        "docker:dev:clean": "docker compose -v -f compose.local.yml down",
+        "docker:dev:fclean": "docker compose -v -f compose.local.yml down --rmi all",
+        "ssl:generate": "cd services/nginx/ssl && bash ./generate-cert.sh"
+    },
+    "dependencies": {
+        "turbo": "^2.3.0"
+    },
+    "private": true,
+    "workspaces": [
+        "apps/*"
+    ],
+    "packageManager": "yarn@1.22.22"
 }

--- a/services/backend/Dockerfile.local
+++ b/services/backend/Dockerfile.local
@@ -1,0 +1,38 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /
+
+# 모노레포 관련 파일 복사
+COPY package.json yarn.lock ./
+COPY turbo.json ./
+COPY apps/backend/package.json ./apps/backend/
+COPY apps/frontend/package.json ./apps/frontend/
+
+# 의존성 설치
+RUN yarn install --frozen-lockfile
+
+# 소스 코드 복사
+COPY apps/backend/ ./apps/backend/
+COPY apps/frontend/ ./apps/frontend/
+
+# 프론트엔드와 백엔드 모두 빌드
+RUN yarn build
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+# 프로덕션 의존성만 설치하기 위한 파일들 복사
+COPY --from=builder package.json yarn.lock ./
+COPY --from=builder apps/backend/package.json ./apps/backend/
+
+# 프로덕션 의존성만 설치
+RUN yarn install --production --frozen-lockfile
+
+# 빌드된 결과물 복사
+COPY --from=builder apps/backend/dist ./apps/backend/dist
+COPY --from=builder apps/frontend/dist ./public/
+
+EXPOSE 3000 1234
+
+CMD ["yarn", "start"]

--- a/services/nginx/Dockerfile.local
+++ b/services/nginx/Dockerfile.local
@@ -1,0 +1,14 @@
+FROM backend:latest AS backend_build
+
+FROM nginx:alpine
+
+# 필요한 설정 파일 복사
+COPY services/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+
+# 빌드된 프론트엔드 파일 복사
+COPY --from=backend_build /app/public /usr/share/nginx/html
+
+# SSL 설정 및 권한 조정
+RUN mkdir -p /etc/nginx/ssl && \
+    chown -R nginx:nginx /etc/nginx/ssl && \
+    chmod 700 /etc/nginx/ssl

--- a/services/nginx/conf.d/default.conf
+++ b/services/nginx/conf.d/default.conf
@@ -1,0 +1,39 @@
+server {
+    listen 80;
+    server_name localhost octodocs.local;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name localhost octodocs.local;
+
+    ssl_certificate /etc/nginx/ssl/localhost.crt;
+    ssl_certificate_key /etc/nginx/ssl/localhost.key;
+
+    # Frontend static files
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache";
+    }
+
+    # Backend API
+    location /api {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # WebSocket
+    location /socket.io {
+        proxy_pass http://backend:1234;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+}

--- a/services/nginx/ssl/generate-cert.sh
+++ b/services/nginx/ssl/generate-cert.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# 스크립트가 위치한 디렉토리로 이동
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+# OpenSSL 설정 파일 생성
+cat > openssl.conf << EOF
+[req]
+default_bits       = 2048
+default_keyfile    = localhost.key
+distinguished_name = req_distinguished_name
+req_extensions     = req_ext
+x509_extensions    = v3_ca
+prompt            = no
+
+[req_distinguished_name]
+C  = KR
+ST = Seoul
+L  = Seoul
+O  = OctoDocs
+OU = Development
+CN = localhost
+
+[req_ext]
+subjectAltName = @alt_names
+
+[v3_ca]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1   = localhost
+DNS.2   = *.localhost
+DNS.3   = octodocs.local
+DNS.4   = *.octodocs.local
+IP.1    = 127.0.0.1
+EOF
+
+# 인증서 생성
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout localhost.key -out localhost.crt -config openssl.conf
+
+chmod 644 localhost.crt
+chmod 644 localhost.key
+
+# 설정 파일 정리
+rm openssl.conf
+
+echo "SSL certificate generated successfully!"
+echo "Certificate: $SCRIPT_DIR/localhost.crt"
+echo "Private key: $SCRIPT_DIR/localhost.key"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8454,6 +8454,62 @@ pause@0.0.1:
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==
 
+pg-cloudflare@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz#e6d5833015b170e23ae819e8c5d7eaedb472ca98"
+  integrity sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==
+
+pg-connection-string@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.7.0.tgz#f1d3489e427c62ece022dba98d5262efcb168b37"
+  integrity sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.7.0.tgz#d4d3c7ad640f8c6a2245adc369bafde4ebb8cbec"
+  integrity sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==
+
+pg-protocol@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.7.0.tgz#ec037c87c20515372692edac8b63cf4405448a93"
+  integrity sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==
+
+pg-types@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.13.1:
+  version "8.13.1"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.13.1.tgz#6498d8b0a87ff76c2df7a32160309d3168c0c080"
+  integrity sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==
+  dependencies:
+    pg-connection-string "^2.7.0"
+    pg-pool "^3.7.0"
+    pg-protocol "^1.7.0"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+  optionalDependencies:
+    pg-cloudflare "^1.1.1"
+
+pgpass@1.x:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
+
 picocolors@^1.0.0, picocolors@^1.0.1, picocolors@^1.1.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -8556,6 +8612,28 @@ postcss@^8.4.43, postcss@^8.4.47:
     nanoid "^3.3.7"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prebuild-install@^7.1.1:
   version "7.1.2"
@@ -9550,6 +9628,11 @@ space-separated-tokens@^2.0.0:
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
   integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
 
+split2@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
 sprintf-js@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
@@ -9604,7 +9687,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9636,7 +9728,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10535,7 +10634,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10548,6 +10647,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- closes #283 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- [x]  로컬 Postgres 설정
    - [x]  도커 컴포즈로 같이 올라가도록 함
    - [x]  로컬 볼륨 마운트
    - [x]  5432 포트만 내부 네트워크로 열어두고, nest 컨테이너가 이를 사용하도록 설정
    - [x]  nest내의 TypeORM 설정 (sqlite3 → Postgres)
- [x]  nest 도커파일 작성
    - [x]  모노레포니까 서버 켜지기 전에 프론트 빌드까지 돌리도록 하면 될듯 → `yarn build`
    - [x]  3000포트를 오픈해두고, nginx가 가리키도록 설정 (REST API)
    - [x]  1234포트를 오픈해두고, nginx가 가리키도록 설정 (웹소켓)
- [x]  nginx 도커파일 작성
    - [x]  80 포트로 들어오면 443 포트로 리다이렉션
    - [x]  SSL 인증서 적용 및 https, wss 테스트
    - [x]  443 포트로 접속 시 프론트 빌드 정적 파일 서빙


## 📑 참고 사항

- 혹시 몰라서 기존 `yarn dev`를 살려놨습니다. (nest의 `app.module.ts` 만 이전으로 돌리면 됩니다.)
- 다음과 같은 설정이 필요합니다.
    - 새로운 백엔드 `.env`를 **프로젝트 루트** 에 두어야 합니다.
    - 기존 프론트엔드 env는 그대로 두고 값만 수정해야 합니다. 
    - 로컬 DNS 수정이 필요합니다.
    ```bash
    # macOS/Linux의 경우
    sudo echo "127.0.0.1 octodocs.local" >> /etc/hosts 
    # 또는
    sudo vim /etc/hosts
    # 맨 마지막 줄에 127.0.0.1 octodocs.local 추가 후 저장

    # Windows의 경우 관리자 권한으로 메모장을 열어 C:\Windows\System32\drivers\etc\hosts 파일에 추가
    # 127.0.0.1 octodocs.local
    ```
- 최초 실행 시, Self-Signed SSL 인증서가 필요합니다. -> `yarn ssl:generate`
- `yarn docker:dev` 입력 시 개발 환경이 구성됩니다. 
    - 일부러 볼륨 마운트 없이 복사하여 빌드하는 방식으로 구성하였습니다. 
    - 따라서 hot-reload가 적용되지 않습니다. 불편하시다면 알려주세요.
- 비상 탈출 버튼: 볼륨과 컨테이너, 이미지를 싹 다 날립니다 -> `yarn docker:fclean` 
- `yarn docker:dev:down`으로 컴포즈를 내리고 `yarn docker:dev`로 다시 올리면 변경 사항이 적용됩니다.

> `git fetch origin && git checkout feature-be-#283` 을 통해 직접 테스트 후 Approve 부탁드립니다
