### PR TITLE
로컬 개발환경 편의성 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 .env*
 *.local
 .turbo
-.crt
-.key
+*.crt
+*.key
 !Dockerfile.local
 
 # compiled output

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "dev": "nest start --watch",
+    "dev": "nest start --tsc --watch --preserveWatchOutput --watchAssets",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -28,7 +28,7 @@ import { RoleModule } from './role/role.module';
     }),
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: path.join(__dirname, '..', '..', '..', '.env'), // * nest 디렉터리 기준
+      envFilePath: '/app/.env', // * docker 내부 디렉터리 기준
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -16,6 +16,9 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+  },
+  "watchOptions": {
+    "watchFile": "fixedPollingInterval"
   }
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -11,7 +11,7 @@
     }
   },
   "scripts": {
-    "dev": "vite --host",
+    "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview --host"

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -10,4 +10,13 @@ export default defineConfig({
       plugins: [tailwindcss()],
     },
   },
+  server: {
+    host: "0.0.0.0",
+    port: 5173,
+    hmr: {
+      protocol: "wss",
+      clientPort: 443,
+      path: "hmr/",
+    },
+  },
 });

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 5173,
+    watch: {
+      usePolling: true,
+      interval: 1000,
+    },
     hmr: {
       protocol: "wss",
       clientPort: 443,

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -24,12 +24,25 @@ services:
         image: backend:latest
         env_file:
             - .env
+        volumes:
+            - .env:/app/.env
+            # 소스 코드 마운트
+            - ./apps/backend:/app/apps/backend
+            - ./apps/frontend:/app/apps/frontend
+            # 의존성 캐시를 위한 볼륨
+            - backend_node_modules:/app/node_modules
+            - backend_app_node_modules:/app/apps/backend/node_modules
+            - frontend_app_node_modules:/app/apps/frontend/node_modules
         depends_on:
             postgres:
                 condition: service_healthy
         networks:
             - backend
             - frontend
+        ports:
+            - "5173:5173" # Vite dev server
+            - "3000:3000" # 백엔드 API 포트
+            - "1234:1234" # WebSocket 포트
 
     nginx:
         build:
@@ -49,6 +62,7 @@ services:
               bind:
                   create_host_path: true
                   propagation: rprivate
+            - ./services/nginx/conf.d:/etc/nginx/conf.d
 
 networks:
     backend:
@@ -57,3 +71,6 @@ networks:
 
 volumes:
     postgres_data:
+    backend_node_modules:
+    backend_app_node_modules:
+    frontend_app_node_modules:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "author": "ez <105545215+ezcolin2@users.noreply.github.com>",
     "license": "MIT",
     "scripts": {
-        "dev": "turbo run dev",
+        "dev": "turbo run dev --parallel",
         "build": "turbo run build",
         "start": "node apps/backend/dist/main.js",
         "lint": "turbo run lint",

--- a/services/backend/Dockerfile.local
+++ b/services/backend/Dockerfile.local
@@ -1,38 +1,19 @@
-FROM node:20-alpine AS builder
+FROM node:20-alpine
 
-WORKDIR /
+WORKDIR /app
 
-# 모노레포 관련 파일 복사
+# 개발 의존성 설치를 위한 파일들
 COPY package.json yarn.lock ./
 COPY turbo.json ./
 COPY apps/backend/package.json ./apps/backend/
 COPY apps/frontend/package.json ./apps/frontend/
 
-# 의존성 설치
-RUN yarn install --frozen-lockfile
+# 개발 의존성 설치 (프로덕션 플래그 제거)
+RUN yarn install
 
-# 소스 코드 복사
-COPY apps/backend/ ./apps/backend/
-COPY apps/frontend/ ./apps/frontend/
-
-# 프론트엔드와 백엔드 모두 빌드
-RUN yarn build
-
-FROM node:20-alpine AS runner
-
-WORKDIR /app
-
-# 프로덕션 의존성만 설치하기 위한 파일들 복사
-COPY --from=builder package.json yarn.lock ./
-COPY --from=builder apps/backend/package.json ./apps/backend/
-
-# 프로덕션 의존성만 설치
-RUN yarn install --production --frozen-lockfile
-
-# 빌드된 결과물 복사
-COPY --from=builder apps/backend/dist ./apps/backend/dist
-COPY --from=builder apps/frontend/dist ./public/
+# 소스 코드는 볼륨으로 마운트할 예정이므로 COPY 불필요
 
 EXPOSE 3000 1234
 
-CMD ["yarn", "start"]
+# 개발 모드로 실행
+CMD ["yarn", "dev"]

--- a/services/nginx/Dockerfile.local
+++ b/services/nginx/Dockerfile.local
@@ -1,12 +1,7 @@
-FROM backend:latest AS backend_build
-
 FROM nginx:alpine
 
 # 필요한 설정 파일 복사
 COPY services/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
-
-# 빌드된 프론트엔드 파일 복사
-COPY --from=backend_build /app/public /usr/share/nginx/html
 
 # SSL 설정 및 권한 조정
 RUN mkdir -p /etc/nginx/ssl && \

--- a/services/nginx/conf.d/default.conf
+++ b/services/nginx/conf.d/default.conf
@@ -11,11 +11,30 @@ server {
     ssl_certificate /etc/nginx/ssl/localhost.crt;
     ssl_certificate_key /etc/nginx/ssl/localhost.key;
 
-    # Frontend static files
+    # Frontend dev server
     location / {
-        root /usr/share/nginx/html;
-        try_files $uri $uri/ /index.html;
-        add_header Cache-Control "no-cache";
+        proxy_pass http://backend:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        
+        # HMR을 위한 설정
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 1800;
+        proxy_connect_timeout 1800;
+    }
+
+    # Vite HMR WebSocket
+    location /hmr {
+        proxy_pass http://backend:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
     }
 
     # Backend API
@@ -35,5 +54,29 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
+    }
+
+    # Vite static assets
+    location /@fs/ {
+        proxy_pass http://backend:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    location /@vite/ {
+        proxy_pass http://backend:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    # CORS preflight requests
+    location = /api/preflight {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
+        add_header 'Access-Control-Allow-Headers' '*';
+        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Content-Type' 'text/plain charset=UTF-8';
+        add_header 'Content-Length' 0;
+        return 204;
     }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,15 +2,12 @@
     "$schema": "https://turbo.build/schema.json",
     "tasks": {
         "dev": {
-            "cache": false
+            "cache": false,
+            "persistent": true
         },
         "build": {
-            "dependsOn": [
-                "^build"
-            ],
-            "outputs": [
-                "dist/**"
-            ]
+            "dependsOn": ["^build"],
+            "outputs": ["dist/**"]
         },
         "lint": {},
         "test": {}


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- closes #300 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- 모노레포 `dev` 커맨드 관련 수정
- 프론트엔드 `vite dev` 빌드 관련 수정
- 로컬용 도커파일 & 컴포즈 개선

## 📑 참고 사항

> 기존과 사용법 자체는 동일합니다. 다시 정리하니 아래 사항을 따라주세요!

1. `.env` 업데이트 및 **프로젝트 루트에 위치** -> 슬랙 dm에 있습니다. 
2. 로컬 DNS 수정 (기존에 진행한 경우 패스)
    ```
    # macOS/Linux의 경우
    sudo echo "127.0.0.1 octodocs.local" >> /etc/hosts 
    # 또는
    sudo vim /etc/hosts
    # 맨 마지막 줄에 127.0.0.1 octodocs.local 추가 후 저장

    # Windows의 경우 관리자 권한으로 메모장을 열어 C:\Windows\System32\drivers\etc\hosts 파일에 추가
    # 127.0.0.1 octodocs.local
    ```
3. `yarn ssl:generate` 실행
    - Windows의 경우 bash 로 실행시키거나 CRLF로 변경하여 관리자 권한으로 실행해주세요.
4. 프로젝트에 존재하는 `yarn.lock` 및 `node_modules` 디렉터리 전부 제거
5. `yarn install`
6. `yarn docker:dev:fclean && docker volume rm web15-octodocs_postgres_data && sudo docker system prune -af`
7. `yarn docker:dev`

`https://octodocs.local` 로 접속하면 됩니다. 도커를 내렸다 올릴 필요 없이, 알아서 코드 수정이 반영됩니다.
DB 초기화가 필요할 경우 다음 절차를 따릅니다.
1. `yarn docker:dev:clean`
2. `docker volume rm web15-octodocs_postgres_data`
3. `yarn docker:dev`

이상있으면 바로 알려주세요! 브랜치 옮겨서 직접 테스트 후 Approve 부탁드립니다.
