### PR TITLE
focus시 줌 상태 유지

### DIFF
--- a/apps/frontend/src/features/canvas/model/useCanvas.ts
+++ b/apps/frontend/src/features/canvas/model/useCanvas.ts
@@ -9,6 +9,7 @@ import {
   EdgeChange,
   Connection,
   useReactFlow,
+  useViewport,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { SocketIOProvider } from "y-socket.io";
@@ -26,6 +27,7 @@ export interface YNode extends Node {
 }
 
 export const useCanvas = () => {
+  const { zoom } = useViewport();
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const { pages } = usePages();
@@ -52,13 +54,8 @@ export const useCanvas = () => {
           nodes: [{ id: currentPage.toString() }],
           duration: 500,
           padding: 0.5,
+          maxZoom: zoom,
         });
-        const nodeElement = document.querySelector(
-          `[data-nodeid="${currentPage}"]`,
-        ) as HTMLInputElement;
-        if (nodeElement) {
-          nodeElement.focus();
-        }
       }, 100);
     }
   }, [currentPage, fitView]);


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

- closes #307 

## 📂 작업 내용

auto-focus시 줌이 확대되지 않고 줌 상태가 유지된다.

## 📑 참고 자료 & 스크린샷 (선택)


https://github.com/user-attachments/assets/6ab3b686-cbc3-4655-abe2-05cf037c2722


## 📢 리뷰 요구사항 (선택)

HTMLElement.focus() 왜 있었는지 확인 부탁드립니다!! 
(없어도 작동은 하는데 살짝 불안합니다ㅜ)
