### PR TITLE
Refresh Token DB 보관 방식으로 보안성 높이기

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -55,6 +55,7 @@
     "socket.io": "^4.8.1",
     "sqlite3": "^5.1.7",
     "typeorm": "^0.3.20",
+    "uuid": "^11.0.3",
     "ws": "^8.14.2",
     "y-prosemirror": "^1.2.12",
     "y-protocols": "^1.0.6",

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -84,9 +84,11 @@ export class AuthController {
   @ApiOperation({ summary: '사용자가 로그아웃합니다.' })
   @Post('logout')
   @UseGuards(JwtAuthGuard) // JWT 인증 검사
-  logout(@Res() res: Response) {
+  logout(@Req() req, @Res() res: Response) {
     // 쿠키 삭제 (옵션이 일치해야 삭제됨)
     this.tokenService.clearCookies(res);
+    // 현재 자동로그인에 사용되는 refresh Token db에서 삭제
+    this.tokenService.deleteRefreshToken(req.user.sub);
     return res.status(200).json({
       message: AuthResponseMessage.AUTH_LOGGED_OUT,
     });

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -41,11 +41,13 @@ export class AuthController {
     // 네이버 인증 후 사용자 정보 반환
     const user = req.user;
 
-    // primary Key인 id 포함 payload 생성함
-    // TODO: 여기서 권한 추가해야함
+    // primary Key인 id 포함 payload 생성, access token 만들기
     const payload = { sub: user.id };
     const accessToken = this.tokenService.generateAccessToken(payload);
-    const refreshToken = this.tokenService.generateRefreshToken(payload);
+
+    // access token 만들어서 db에도 저장
+    const refreshToken = this.tokenService.generateRefreshToken();
+    this.authService.updateRefreshToken(user.id, refreshToken);
 
     // 토큰을 쿠키에 담아서 메인 페이지로 리디렉션
     this.tokenService.setAccessTokenCookie(res, accessToken);
@@ -67,11 +69,13 @@ export class AuthController {
     /// 카카오 인증 후 사용자 정보 반환
     const user = req.user;
 
-    // primary Key인 id 포함 payload 생성함
-    // TODO: 여기서 권한 추가해야함
+    // primary Key인 id 포함 payload 생성, access token 만들기
     const payload = { sub: user.id };
     const accessToken = this.tokenService.generateAccessToken(payload);
-    const refreshToken = this.tokenService.generateRefreshToken(payload);
+
+    // access token 만들어서 db에도 저장
+    const refreshToken = this.tokenService.generateRefreshToken();
+    this.authService.updateRefreshToken(user.id, refreshToken);
 
     // 토큰을 쿠키에 담아서 메인 페이지로 리디렉션
     this.tokenService.setAccessTokenCookie(res, accessToken);
@@ -94,7 +98,6 @@ export class AuthController {
 
   // 클라이언트가 사용자의 외부 id(snowflakeId) + 이름을 알 수 있는 엔드포인트
   // auth/profile
-  // TODO: 사용자 지정 닉네임 + 프로필 이미지도 return하게 확장
   @Get('profile')
   @UseGuards(JwtAuthGuard) // JWT 인증 검사
   async getProfile(@Req() req) {

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -41,13 +41,11 @@ export class AuthController {
     // 네이버 인증 후 사용자 정보 반환
     const user = req.user;
 
-    // primary Key인 id 포함 payload 생성, access token 만들기
-    const payload = { sub: user.id };
-    const accessToken = this.tokenService.generateAccessToken(payload);
+    // access token 만들기
+    const accessToken = this.tokenService.generateAccessToken(user.id);
 
-    // access token 만들어서 db에도 저장
-    const refreshToken = this.tokenService.generateRefreshToken();
-    this.authService.updateRefreshToken(user.id, refreshToken);
+    // refresh token 만들어서 db에도 저장
+    const refreshToken = await this.tokenService.generateRefreshToken(user.id);
 
     // 토큰을 쿠키에 담아서 메인 페이지로 리디렉션
     this.tokenService.setAccessTokenCookie(res, accessToken);
@@ -69,13 +67,11 @@ export class AuthController {
     /// 카카오 인증 후 사용자 정보 반환
     const user = req.user;
 
-    // primary Key인 id 포함 payload 생성, access token 만들기
-    const payload = { sub: user.id };
-    const accessToken = this.tokenService.generateAccessToken(payload);
+    // access token 만들기
+    const accessToken = this.tokenService.generateAccessToken(user.id);
 
-    // access token 만들어서 db에도 저장
-    const refreshToken = this.tokenService.generateRefreshToken();
-    this.authService.updateRefreshToken(user.id, refreshToken);
+    // refresh token 만들어서 db에도 저장
+    const refreshToken = await this.tokenService.generateRefreshToken(user.id);
 
     // 토큰을 쿠키에 담아서 메인 페이지로 리디렉션
     this.tokenService.setAccessTokenCookie(res, accessToken);

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -61,18 +61,4 @@ export class AuthService {
     // DB에 있는 값과 일치하는지 비교한다
     return user.refreshToken === refreshToken;
   }
-
-  async updateRefreshToken(id: number, refreshToken: string) {
-    // 유저를 찾는다.
-    const user = await this.userRepository.findOneBy({ id });
-
-    // 유저가 없으면 오류
-    if (!user) {
-      throw new UserNotFoundException();
-    }
-
-    // 유저의 현재 REFRESH TOKEN 갱신
-    user.refreshToken = refreshToken;
-    await this.userRepository.save(user);
-  }
 }

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -31,6 +31,7 @@ export class AuthService {
   async findUserById(id: number): Promise<User | null> {
     return await this.userRepository.findOneBy({ id });
   }
+
   async updateUser(id: number, dto: UpdateUserDto) {
     // 유저를 찾는다.
     const findUser = await this.userRepository.findOneBy({ id });
@@ -43,5 +44,35 @@ export class AuthService {
     // 유저 갱신
     const newPage = Object.assign({}, findUser, dto);
     await this.userRepository.save(newPage);
+  }
+
+  async compareStoredRefreshToken(
+    id: number,
+    refreshToken: string,
+  ): Promise<boolean> {
+    // 유저를 찾는다.
+    const user = await this.userRepository.findOneBy({ id });
+
+    // 유저가 없으면 오류
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    // DB에 있는 값과 일치하는지 비교한다
+    return user.refreshToken === refreshToken;
+  }
+
+  async updateRefreshToken(id: number, refreshToken: string) {
+    // 유저를 찾는다.
+    const user = await this.userRepository.findOneBy({ id });
+
+    // 유저가 없으면 오류
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    // 유저의 현재 REFRESH TOKEN 갱신
+    user.refreshToken = refreshToken;
+    await this.userRepository.save(user);
   }
 }

--- a/apps/backend/src/auth/token/token.module.ts
+++ b/apps/backend/src/auth/token/token.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { TokenService } from './token.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { UserModule } from '../../user/user.module';
 
 @Module({
   imports: [
+    UserModule,
     ConfigModule, // ConfigModule 등록
     JwtModule.registerAsync({
       imports: [ConfigModule], // ConfigModule에서 환경 변수 로드

--- a/apps/backend/src/auth/token/token.service.ts
+++ b/apps/backend/src/auth/token/token.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
+import { UserRepository } from '../../user/user.repository';
+import { UserNotFoundException } from '../../exception/user.exception';
+import { InvalidTokenException } from '../../exception/invalid.exception';
 
 const HOUR = 60 * 60;
 const DAY = 24 * 60 * 60;
@@ -10,21 +13,27 @@ const MS_HALF_YEAR = 6 * 30 * 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class TokenService {
-  constructor(private readonly jwtService: JwtService) {}
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly userRepository: UserRepository,
+  ) {}
 
-  generateAccessToken(payload: any): string {
+  generateAccessToken(userId: number): string {
+    const payload = { sub: userId };
     return this.jwtService.sign(payload, {
       expiresIn: HOUR,
     });
   }
 
-  generateRefreshToken(): string {
-    const payload = {
-      jti: uuidv4(),
-    };
-    return this.jwtService.sign(payload, {
+  async generateRefreshToken(userId: number): Promise<string> {
+    const payload = { sub: userId, jti: uuidv4() };
+    const refreshToken = this.jwtService.sign(payload, {
       expiresIn: FIVE_MONTHS,
     });
+
+    await this.updateRefreshToken(userId, refreshToken);
+
+    return refreshToken;
   }
 
   generateInviteToken(workspaceId: number, role: string): string {
@@ -42,16 +51,23 @@ export class TokenService {
     });
   }
 
-  // 후에 DB 로직 (지금은 refreshToken이 DB로 관리 X)
-  // 추가될 때를 위해 일단 비동기 선언
   async refreshAccessToken(refreshToken: string): Promise<string> {
-    // refreshToken을 검증한다
+    // refreshToken 1차 검증한다
     const decoded = this.jwtService.verify(refreshToken, {
       secret: process.env.JWT_SECRET,
     });
 
+    // 검증된 토큰에서 사용자 ID 추출
+    const userId = decoded.sub;
+
+    // DB에 저장된 refreshToken과 비교
+    const isValid = await this.compareStoredRefreshToken(userId, refreshToken);
+    if (!isValid) {
+      throw new InvalidTokenException();
+    }
+
     // 새로운 accessToken을 발급한다
-    return this.generateAccessToken({ sub: decoded.sub });
+    return this.generateAccessToken(decoded.sub);
   }
 
   setAccessTokenCookie(response: Response, accessToken: string): void {
@@ -85,5 +101,35 @@ export class TokenService {
       secure: true,
       sameSite: 'strict',
     });
+  }
+
+  private async compareStoredRefreshToken(
+    id: number,
+    refreshToken: string,
+  ): Promise<boolean> {
+    // 유저를 찾는다.
+    const user = await this.userRepository.findOneBy({ id });
+
+    // 유저가 없으면 오류
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    // DB에 있는 값과 일치하는지 비교한다
+    return user.refreshToken === refreshToken;
+  }
+
+  private async updateRefreshToken(id: number, refreshToken: string) {
+    // 유저를 찾는다.
+    const user = await this.userRepository.findOneBy({ id });
+
+    // 유저가 없으면 오류
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    // 유저의 현재 REFRESH TOKEN 갱신
+    user.refreshToken = refreshToken;
+    await this.userRepository.save(user);
   }
 }

--- a/apps/backend/src/auth/token/token.service.ts
+++ b/apps/backend/src/auth/token/token.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Response } from 'express';
+import { v4 as uuidv4 } from 'uuid';
 
 const HOUR = 60 * 60;
 const DAY = 24 * 60 * 60;
@@ -17,7 +18,10 @@ export class TokenService {
     });
   }
 
-  generateRefreshToken(payload: any): string {
+  generateRefreshToken(): string {
+    const payload = {
+      jti: uuidv4(),
+    };
     return this.jwtService.sign(payload, {
       expiresIn: FIVE_MONTHS,
     });

--- a/apps/backend/src/user/user.entity.ts
+++ b/apps/backend/src/user/user.entity.ts
@@ -36,6 +36,9 @@ export class User {
   @Column({ nullable: true })
   profileImage: string;
 
+  @Column({ nullable: true })
+  refreshToken: string;
+
   @CreateDateColumn()
   createdAt: Date;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10798,6 +10798,11 @@ uuid@9.0.1, uuid@^9.0.0, uuid@^9.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
+uuid@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.3.tgz#248451cac9d1a4a4128033e765d137e2b2c49a3d"
+  integrity sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==
+
 uvu@^0.5.0:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.6.tgz#2754ca20bcb0bb59b64e9985e84d2e81058502df"


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- closes #318

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- 현재는 access Token, refresh Token이 같은 키로 생성되며, jwtService만이 verify하여 검증하는 구조를 가지고 있어 refesh token의 의미가 딱히 없는 상태 입니다 
- refresh Token을 DB에 저장해야하는 이유는 다음과 같습니다 
  - 1. jwt secret key를 얻는 다면 access, refresh Token을 둘 다 위조해낼 수 있는 상황입니다. access Token은 1시간 정도의 유효기간을 가지고 있어 보안에 크게 위협이 되지 않는 상황이지만, 유효기간이 긴 refresh Token과 같은 경우에는 문제가 됩니다. 따라서 사용자의 유효한 refresh Token을 사용자 별로 하나로 특정해 놓는 것이 보안상 좋습니다.
  - 2. jwt는 Stateless 원칙으로, 인증 후 토큰 폐기가 어렵기 때문에 로그아웃 등 기타 정책에 의해 Token을 DB에서 폐기함으로써 특정 토큰을 관리할 수 있습니다.
 
따라서 다음과 같은 구현을 진행했습니다.
1. user 엔티티에 refresh Token column 추가 (nullable, string type)
2. 사용자가 로그인 후 refresh Token, access Token을 쿠키에 보관하면서 refresh Token은 따로 DB에도 저장.
3. refresh Token 생성 방법도 보안성을 높임. 토큰 아이디를 uuid로 payload로 추가.
4. access Token이 만료되어 다시 발급받기 위해 refresh Token을 검증받을 때, refresh Token을 verify 한 후 DB에 보관된 refresh Token과 일치하는지도 비교하게 함. 다른 경우 invalid token error가 생성됨.
5. 사용자가 로그아웃 할 시 쿠키가 비워지면서 db에 있는 해당 사용자의 refresh Token도 null로 reset 됨 

## 📑 참고 자료 & 스크린샷 (선택)

## 📢 리뷰 요구사항 (선택)
- db에 보관된 refresh token과 같은 경우 모두 tokenService가 관리합니다. refresh Token을 생성해서 업데이트, 로그아웃이 진행되어 null로 비우기, 토큰 검증과정에서 비교하기 등의 작업을 모두 tokenService에서 작업하도록 구현하였습니다. 
- 사용자당 하나의 refresh token만이 유효하기 때문에 다른 브라우저로 로그인 시, 원래 로그인 되어있던 브라우저는 로그아웃 처리될 것입니다. 이에 대해 어떻게 생각하시나요? 일단은 크게 불편한 사항은 아니라고 생각해서 user entity에 하나만 보관되게 만들었습니다. (아닐 경우 refresh token 전용 테이블을 하나 만들어야 할수도...)

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
