### PR TITLE
workspace 정보조회 api 구현

### DIFF
--- a/apps/backend/src/workspace/dtos/getWorkspaceResponse.dto.ts
+++ b/apps/backend/src/workspace/dtos/getWorkspaceResponse.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+import { UserWorkspaceDto } from './userWorkspace.dto';
+
+export class GetWorkspaceResponseDto {
+  @ApiProperty({
+    example: 'OO 생성에 성공했습니다.',
+    description: 'api 요청 결과 메시지',
+  })
+  @IsString()
+  message: string;
+
+  @ApiProperty({
+    example: [
+      {
+        workspaceId: 'snowflake-id-1',
+        title: 'naver-boostcamp-9th',
+        description: '네이버 부스트캠프 9기 워크스페이스입니다',
+        thumbnailUrl: 'https://example.com/image1.png',
+        role: 'guest',
+        visibility: 'private',
+      },
+    ],
+    description: '사용자가 접근하려고 하는 워크스페이스 데이터',
+  })
+  workspace: UserWorkspaceDto;
+}

--- a/apps/backend/src/workspace/dtos/userWorkspace.dto.ts
+++ b/apps/backend/src/workspace/dtos/userWorkspace.dto.ts
@@ -3,6 +3,6 @@ export class UserWorkspaceDto {
   title: string;
   description: string | null;
   thumbnailUrl: string | null;
-  role: 'owner' | 'guest';
+  role: 'owner' | 'guest' | null;
   visibility: 'public' | 'private';
 }

--- a/apps/backend/src/workspace/workspace.controller.ts
+++ b/apps/backend/src/workspace/workspace.controller.ts
@@ -20,6 +20,7 @@ import { CreateWorkspaceDto } from './dtos/createWorkspace.dto';
 import { CreateWorkspaceResponseDto } from './dtos/createWorkspaceResponse.dto';
 import { GetUserWorkspacesResponseDto } from './dtos/getUserWorkspacesResponse.dto';
 import { CreateWorkspaceInviteUrlDto } from './dtos/createWorkspaceInviteUrl.dto';
+import { GetWorkspaceResponseDto } from './dtos/getWorkspaceResponse.dto';
 
 export enum WorkspaceResponseMessage {
   WORKSPACE_CREATED = '워크스페이스를 생성했습니다.',
@@ -27,7 +28,7 @@ export enum WorkspaceResponseMessage {
   WORKSPACES_RETURNED = '사용자가 참여하고 있는 모든 워크스페이스들을 가져왔습니다.',
   WORKSPACE_INVITED = '워크스페이스 게스트 초대 링크가 생성되었습니다.',
   WORKSPACE_JOINED = '워크스페이스에 게스트로 등록되었습니다.',
-  WORKSPACE_ACCESS_CHECKED = '워크스페이스에 대한 사용자의 접근 권한이 확인되었습니다.',
+  WORKSPACE_DATA_RETURNED = '워크스페이스에 대한 정보를 가져왔습니다.',
   WORKSPACE_UPDATED_TO_PUBLIC = '워크스페이스가 공개로 설정되었습니다.',
   WORKSPACE_UPDATED_TO_PRIVATE = '워크스페이스가 비공개로 설정되었습니다.',
 }
@@ -134,14 +135,14 @@ export class WorkspaceController {
   }
 
   @ApiResponse({
-    type: MessageResponseDto,
+    type: GetWorkspaceResponseDto,
   })
   @ApiOperation({
     summary: '워크스페이스에 대한 사용자의 권한을 확인합니다.',
   })
   @Get('/:workspaceId/:userId')
   @HttpCode(HttpStatus.OK)
-  async checkWorkspaceAccess(
+  async getWorkspace(
     @Param('workspaceId') workspaceId: string,
     @Param('userId') userId: string, // 로그인되지 않은 경우 'null'
   ) {
@@ -149,10 +150,14 @@ export class WorkspaceController {
     // userId 'null'인 경우 => null로 처리
     const checkedUserId = userId === 'null' ? null : userId;
 
-    await this.workspaceService.checkAccess(checkedUserId, workspaceId);
+    const workspaceData = await this.workspaceService.getWorkspaceData(
+      checkedUserId,
+      workspaceId,
+    );
 
     return {
-      message: WorkspaceResponseMessage.WORKSPACE_ACCESS_CHECKED,
+      message: WorkspaceResponseMessage.WORKSPACE_DATA_RETURNED,
+      workspace: workspaceData,
     };
   }
 

--- a/apps/backend/src/workspace/workspace.service.spec.ts
+++ b/apps/backend/src/workspace/workspace.service.spec.ts
@@ -13,6 +13,7 @@ import { User } from '../user/user.entity';
 import { TokenService } from '../auth/token/token.service';
 import { ForbiddenAccessException } from '../exception/access.exception';
 import { Snowflake } from '@theinternetfolks/snowflake';
+import { UserWorkspaceDto } from './dtos/userWorkspace.dto';
 
 describe('WorkspaceService', () => {
   let service: WorkspaceService;
@@ -357,46 +358,96 @@ describe('WorkspaceService', () => {
     });
   });
 
-  describe('checkAccess', () => {
-    it('퍼블릭 워크스페이스는 접근을 허용한다.', async () => {
-      jest
-        .spyOn(workspaceRepository, 'findOne')
-        .mockResolvedValue({ visibility: 'public' } as Workspace);
+  describe('getWorkspaceData', () => {
+    it('퍼블릭 워크스페이스는 권한 체크 없이 데이터를 받는다.', async () => {
+      const workspace = {
+        id: 1,
+        snowflakeId: 'workspace-snowflake-id',
+        owner: { id: 1 } as User,
+        title: 'Test Workspace',
+        description: null,
+        visibility: 'public',
+        thumbnailUrl: null,
+      } as Workspace;
 
-      await expect(
-        service.checkAccess(null, 'workspace-snowflake-id'),
-      ).resolves.toBeUndefined();
+      const workspaceDto = {
+        workspaceId: 'workspace-snowflake-id',
+        title: 'Test Workspace',
+        description: null,
+        thumbnailUrl: null,
+        role: null,
+        visibility: 'public',
+      } as UserWorkspaceDto;
+
+      jest.spyOn(workspaceRepository, 'findOne').mockResolvedValue(workspace);
+
+      const result = await service.getWorkspaceData(
+        null,
+        'workspace-snowflake-id',
+      );
+
+      expect(result).toEqual(workspaceDto);
     });
 
     it('프라이빗 워크스페이스는 권한이 없으면 예외를 던진다.', async () => {
-      jest
-        .spyOn(workspaceRepository, 'findOne')
-        .mockResolvedValue({ visibility: 'private' } as Workspace);
+      const workspace = {
+        id: 1,
+        snowflakeId: 'workspace-snowflake-id',
+        owner: { id: 2 } as User,
+        title: 'Test Workspace',
+        description: null,
+        visibility: 'private',
+        thumbnailUrl: null,
+      } as Workspace;
+
+      jest.spyOn(workspaceRepository, 'findOne').mockResolvedValue(workspace);
       jest
         .spyOn(userRepository, 'findOneBy')
-        .mockResolvedValue({ id: 1 } as User);
+        .mockResolvedValue({ id: 1, snowflakeId: 'user-snowflake-id' } as User);
       jest.spyOn(roleRepository, 'findOne').mockResolvedValue(null);
 
       await expect(
-        service.checkAccess('user-snowflake-id', 'workspace-snowflake-id'),
+        service.getWorkspaceData('user-snowflake-id', 'workspace-snowflake-id'),
       ).rejects.toThrow(ForbiddenAccessException);
     });
 
     it('프라이빗 워크스페이스는 권한이 있으면 접근을 허용한다.', async () => {
-      const userMock = { id: 1 };
-      const workspaceMock = { id: 1, visibility: 'private' };
+      const workspace = {
+        id: 1,
+        snowflakeId: 'workspace-snowflake-id',
+        owner: { id: 2 } as User,
+        title: 'Test Workspace',
+        description: null,
+        visibility: 'private',
+        thumbnailUrl: null,
+      } as Workspace;
+      const user = {
+        id: 1,
+        snowflakeId: 'user-snowflake-id',
+      } as User;
+      const role = {
+        workspace: workspace,
+        user: user,
+        role: 'guest',
+      } as Role;
+      const workspaceDto = {
+        workspaceId: 'workspace-snowflake-id',
+        title: 'Test Workspace',
+        description: null,
+        thumbnailUrl: null,
+        role: 'guest',
+        visibility: 'private',
+      } as UserWorkspaceDto;
+      jest.spyOn(workspaceRepository, 'findOne').mockResolvedValue(workspace);
+      jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(user);
+      jest.spyOn(roleRepository, 'findOne').mockResolvedValue(role);
 
-      jest
-        .spyOn(workspaceRepository, 'findOne')
-        .mockResolvedValue(workspaceMock as Workspace);
-      jest
-        .spyOn(userRepository, 'findOneBy')
-        .mockResolvedValue(userMock as User);
-      jest.spyOn(roleRepository, 'findOne').mockResolvedValue({} as Role);
+      const result = await service.getWorkspaceData(
+        'user-snowflake-id',
+        'workspace-snowflake-id',
+      );
 
-      await expect(
-        service.checkAccess('user-snowflake-id', 'workspace-snowflake-id'),
-      ).resolves.toBeUndefined();
+      expect(result).toEqual(workspaceDto);
     });
   });
 });

--- a/apps/backend/src/workspace/workspace.service.ts
+++ b/apps/backend/src/workspace/workspace.service.ts
@@ -106,8 +106,8 @@ export class WorkspaceService {
     return userRoles.map((role) => ({
       workspaceId: role.workspace.snowflakeId,
       title: role.workspace.title,
-      description: role.workspace.description || null,
-      thumbnailUrl: role.workspace.thumbnailUrl || null,
+      description: role.workspace.description,
+      thumbnailUrl: role.workspace.thumbnailUrl,
       role: role.role as 'owner' | 'guest',
       visibility: role.workspace.visibility as 'public' | 'private',
     }));
@@ -168,7 +168,10 @@ export class WorkspaceService {
     });
   }
 
-  async checkAccess(userId: string | null, workspaceId: string): Promise<void> {
+  async getWorkspaceData(
+    userId: string | null,
+    workspaceId: string,
+  ): Promise<UserWorkspaceDto> {
     // workspace가 존재하는지 확인
     const workspace = await this.workspaceRepository.findOne({
       where: { snowflakeId: workspaceId },
@@ -180,7 +183,14 @@ export class WorkspaceService {
 
     // 퍼블릭 워크스페이스인 경우
     if (workspace.visibility === 'public') {
-      return;
+      return {
+        workspaceId: workspace.snowflakeId,
+        title: workspace.title,
+        description: workspace.description,
+        thumbnailUrl: workspace.thumbnailUrl,
+        role: null,
+        visibility: 'public',
+      };
     }
 
     // 사용자 인증 필요
@@ -199,7 +209,15 @@ export class WorkspaceService {
 
       // role이 존재하면 접근 허용
       if (role) {
-        return;
+        // 각 워크스페이스와 역할 정보를 가공하여 반환
+        return {
+          workspaceId: workspace.snowflakeId,
+          title: workspace.title,
+          description: workspace.description,
+          thumbnailUrl: workspace.thumbnailUrl,
+          role: role.role as 'owner' | 'guest',
+          visibility: 'private',
+        };
       }
     }
 


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- closes #362

## 📂 작업 내용

### 워크스페이스 접근 권한 확인 + 데이터 얻기
- 먼저 `GET /api/auth/profile`로 사용자의 snowflakeId부터 얻어야합니다 (로그인 안된 상태면 403 Forbidden 돌아옴)
- Endpoint: `GET /api/workspace/:workspaceId/:userId`
- Description: 특정 워크스페이스에 대한 사용자의 접근 권한을 확인합니다.
- 요청 파라미터:
  - workspaceId: 워크스페이스의 snowflakeId (URL Path Parameter)
  - userId: 사용자의 snowflakeId (로그인하지 않은 경우 'null'로 전달)
- 응답:
  - HTTP Status: 200 OK
  - Response Body:
```json
{
  "message": "워크스페이스 접근 권한이 확인되었습니다.",
  "workspace": 
    {
      "workspaceId": "snowflake-id-1",
      "title": "워크스페이스 제목",
      "description": "워크스페이스 설명",
      "thumbnailUrl": "https://example.com/image.png",
      "role": "owner", // public workspace의 경우 role은 null로 돌아옴
      "visibility": "public"
    },
}
```
- 워크스페이스 객체:
  - workspaceId (string) - 워크스페이스의 ID.
  - title (string) - 워크스페이스 제목.
  - description (string/null) - 워크스페이스 설명.
  - thumbnailUrl (string/null) - 워크스페이스의 썸네일 이미지 URL.
  - role (string/null) - 사용자가 해당 워크스페이스에서 가지고 있는 역할 (owner 또는 guest 또는 null => visibillity public의 경우).
  - visibility (string) - 워크스페이스의 전체공개 / 일부 공개 (public 또는 privat)
  - 예외:
    - 404 Not Found: 워크스페이스 또는 사용자를 찾을 수 없음
    - 403 Forbidden: 워크스페이스 접근 권한 없음

## 📑 참고 자료 & 스크린샷 (선택)
![스크린샷 2024-12-02 16-44-53](https://github.com/user-attachments/assets/7c4c8f98-59ca-4e27-b033-f01935aa8456)


## 📢 리뷰 요구사항 (선택)

<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
