### PR TITLE
초기 사이트 접속 시 에디터 소켓 접속하는 문제 해결

### DIFF
--- a/apps/frontend/src/features/editor/model/useEditorConnection.ts
+++ b/apps/frontend/src/features/editor/model/useEditorConnection.ts
@@ -11,6 +11,8 @@ export const useEdtorConnection = (currentPage: number | null) => {
       editor.provider.destroy();
     }
 
+    if (currentPage === null) return;
+
     setConnectionStatus("editor", "connecting");
 
     const provider = createSocketIOProvider(


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

- closes #416

## 📂 작업 내용

초기 접속 시 에디터 소켓에 연결 하지 않는다.