### PR TITLE
feat: 프로덕션 배포 자동화 시스템 구축

### DIFF
--- a/compose.deploy.yml
+++ b/compose.deploy.yml
@@ -1,5 +1,8 @@
 version: "3.8"
 
+# OctoDocs 프로덕션 배포용 Docker Compose
+# compose.local.yml 기반, octodocs.site 도메인 사용
+
 services:
     postgres:
         image: postgres:16-alpine
@@ -16,8 +19,7 @@ services:
             interval: 10s
             timeout: 5s
             retries: 5
-        ports:
-            - "5432:5432"
+        restart: always
 
     redis:
         image: redis:latest
@@ -26,14 +28,13 @@ services:
             REDIS_PORT: ${REDIS_PORT}
         networks:
             - net
-        ports:
-            - "6379:6379"
         healthcheck:
             test: ["CMD", "redis-cli", "ping"]
             interval: 30s
             retries: 3
             start_period: 10s
             timeout: 5s
+        restart: always
 
     backend:
         build:
@@ -41,9 +42,9 @@ services:
             dockerfile: ./services/backend/Dockerfile.local
         image: backend:latest
         env_file:
-            - .env
+            - .env.deploy
         volumes:
-            - .env:/app/.env
+            - .env.deploy:/app/.env
             # 소스 코드 마운트
             - ./apps/backend:/app/apps/backend
             - ./apps/frontend:/app/apps/frontend
@@ -58,15 +59,16 @@ services:
                 condition: service_healthy
         networks:
             - net
-        ports:
-            - "5173:5173" # Vite dev server
-            - "3000:3000" # 백엔드 API 포트
+        expose:
+            - "5173"
+            - "3000"
         healthcheck:
             test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
             interval: 10s
             timeout: 5s
             retries: 5
             start_period: 30s
+        restart: always
 
     websocket:
         build:
@@ -74,9 +76,9 @@ services:
             dockerfile: ./services/websocket/Dockerfile.local
         image: websocket:latest
         env_file:
-            - .env
+            - .env.deploy
         volumes:
-            - .env:/app/.env
+            - .env.deploy:/app/.env
             # 소스 코드 마운트
             - ./apps/websocket:/app/apps/websocket
             # 의존성 캐시를 위한 볼륨
@@ -89,14 +91,15 @@ services:
                 condition: service_healthy
         networks:
             - net
-        ports:
-            - "4242:4242" # WebSocket 포트
+        expose:
+            - "4242"
         healthcheck:
             test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4242/health"]
             interval: 10s
             timeout: 5s
             retries: 5
             start_period: 30s
+        restart: always
 
     nginx:
         build:
@@ -113,13 +116,22 @@ services:
         networks:
             - net
         volumes:
-            - type: bind
-              source: ./services/nginx/ssl
-              target: /etc/nginx/ssl
-              bind:
-                  create_host_path: true
-                  propagation: rprivate
-            - ./services/nginx/conf.d:/etc/nginx/conf.d
+            # Let's Encrypt 인증서 마운트
+            - ./data/certbot/conf:/etc/letsencrypt:ro
+            - ./data/certbot/www:/var/www/certbot:ro
+            # 프로덕션 nginx 설정 사용
+            - ./services/nginx/conf.d/default.deploy.conf:/etc/nginx/conf.d/default.conf:ro
+        restart: always
+
+    # SSL 인증서 자동 갱신
+    certbot-renewer:
+        image: certbot/certbot:latest
+        volumes:
+            - ./data/certbot/conf:/etc/letsencrypt
+            - ./data/certbot/www:/var/www/certbot
+            - ./data/certbot/log:/var/log/letsencrypt
+        entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot --webroot-path=/var/www/certbot; sleep 12h & wait $${!}; done;'"
+        restart: always
 
 networks:
     net:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,13 @@
         "docker:dev:down": "docker compose -f compose.local.yml down",
         "docker:dev:clean": "docker compose -v -f compose.local.yml down",
         "docker:dev:fclean": "docker compose -v -f compose.local.yml down --rmi all",
-        "ssl:generate": "cd services/nginx/ssl && bash ./generate-cert.sh"
+        "ssl:generate": "cd services/nginx/ssl && bash ./generate-cert.sh",
+        "deploy:init": "bash scripts/deploy-init.sh",
+        "deploy": "docker compose -f compose.deploy.yml up -d --build",
+        "deploy:down": "docker compose -f compose.deploy.yml down",
+        "deploy:logs": "docker compose -f compose.deploy.yml logs -f",
+        "deploy:restart": "docker compose -f compose.deploy.yml restart",
+        "deploy:clean": "docker compose -v -f compose.deploy.yml down"
     },
     "dependencies": {
         "turbo": "^2.3.0"

--- a/scripts/deploy-init.sh
+++ b/scripts/deploy-init.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# OctoDocs 프로덕션 배포 초기화 스크립트
+# Let's Encrypt SSL 인증서 자동 발급
+
+set -e
+
+echo "🚀 OctoDocs 프로덕션 배포 초기화 시작..."
+echo ""
+
+# 프로젝트 루트 디렉토리로 이동
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+# .env.deploy 파일 확인
+if [ ! -f .env.deploy ]; then
+    echo "❌ .env.deploy 파일이 없습니다."
+    exit 1
+fi
+
+echo "✅ .env.deploy 파일 확인 완료"
+
+# certbot 데이터 디렉토리 생성
+mkdir -p data/certbot/conf
+mkdir -p data/certbot/www
+mkdir -p data/certbot/log
+
+echo "✅ certbot 디렉토리 생성 완료"
+
+# 도메인 설정
+DOMAIN="octodocs.site"
+EMAIL="hihj070914@icloud.com"
+
+echo ""
+echo "📋 SSL 인증서 발급 정보:"
+echo "   도메인: $DOMAIN, www.$DOMAIN"
+echo "   이메일: $EMAIL"
+echo ""
+
+# 기존 인증서 확인
+if [ -d "data/certbot/conf/live/$DOMAIN" ]; then
+    echo "⚠️  기존 인증서가 존재합니다."
+    read -p "기존 인증서를 삭제하고 재발급하시겠습니까? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "✅ 기존 인증서를 유지합니다."
+        exit 0
+    fi
+    echo "🗑️  기존 인증서 삭제 중..."
+    rm -rf data/certbot/conf/live/$DOMAIN
+    rm -rf data/certbot/conf/archive/$DOMAIN
+    rm -rf data/certbot/conf/renewal/$DOMAIN.conf
+fi
+
+# compose.init.yml을 사용하여 certbot 실행
+echo ""
+echo "🔐 Let's Encrypt SSL 인증서 발급 중..."
+echo "   (약 1-2분 소요됩니다)"
+echo ""
+
+docker compose -f compose.init.yml up certbot
+
+# 발급 결과 확인
+if [ -d "data/certbot/conf/live/$DOMAIN" ]; then
+    echo ""
+    echo "✅ SSL 인증서 발급 완료!"
+    echo ""
+    echo "📂 인증서 위치:"
+    echo "   - 인증서: data/certbot/conf/live/$DOMAIN/fullchain.pem"
+    echo "   - 개인키: data/certbot/conf/live/$DOMAIN/privkey.pem"
+    echo ""
+    echo "🎉 이제 'yarn deploy' 명령어로 배포할 수 있습니다!"
+else
+    echo ""
+    echo "❌ SSL 인증서 발급 실패"
+    echo ""
+    echo "💡 다음 사항을 확인해주세요:"
+    echo "   1. 도메인 DNS가 이 서버 IP를 가리키는지 확인"
+    echo "   2. 80번 포트가 열려있는지 확인"
+    echo "   3. 방화벽 설정 확인"
+    echo ""
+    echo "📝 로그 확인: data/certbot/log/"
+    exit 1
+fi
+
+# compose.init.yml 정리
+docker compose -f compose.init.yml down
+
+echo ""
+echo "✅ 초기화 완료!"

--- a/services/backend/Dockerfile.local
+++ b/services/backend/Dockerfile.local
@@ -15,5 +15,6 @@ RUN yarn install
 
 EXPOSE 3000
 
-# 개발 모드로 실행
+# Backend만 개발 모드로 실행
+WORKDIR /app/apps/backend
 CMD ["yarn", "dev"]

--- a/services/nginx/conf.d/default.deploy.conf
+++ b/services/nginx/conf.d/default.deploy.conf
@@ -1,0 +1,117 @@
+# OctoDocs 프로덕션 배포용 Nginx 설정
+# octodocs.site 도메인 사용
+
+# HTTP → HTTPS 리다이렉트
+server {
+    listen 80;
+    server_name octodocs.site www.octodocs.site;
+
+    # Let's Encrypt ACME Challenge
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS 서버
+server {
+    listen 443 ssl http2;
+    server_name octodocs.site www.octodocs.site;
+
+    # Let's Encrypt SSL 인증서
+    ssl_certificate /etc/letsencrypt/live/octodocs.site/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/octodocs.site/privkey.pem;
+
+    # SSL 보안 설정
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    # Frontend dev server (Vite)
+    location / {
+        proxy_pass http://backend:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+
+        # HMR을 위한 타임아웃 설정
+        proxy_read_timeout 1800;
+        proxy_connect_timeout 1800;
+    }
+
+    # Vite HMR WebSocket
+    location /hmr {
+        proxy_pass http://backend:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Backend API
+    location /api {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # WebSocket for YJS (실시간 협업)
+    location /socket.io {
+        proxy_pass http://websocket:4242;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # WebSocket 연결 안정성을 위한 추가 설정
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+
+    # Vite static assets
+    location /@fs/ {
+        proxy_pass http://backend:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    location /@vite/ {
+        proxy_pass http://backend:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    # CORS preflight requests
+    location = /api/preflight {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
+        add_header 'Access-Control-Allow-Headers' '*';
+        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Content-Type' 'text/plain charset=UTF-8';
+        add_header 'Content-Length' 0;
+        return 204;
+    }
+
+    # 보안 헤더
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+}

--- a/services/websocket/Dockerfile.local
+++ b/services/websocket/Dockerfile.local
@@ -2,18 +2,18 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Install dependencies
+# 개발 의존성 설치를 위한 파일들
 COPY package.json yarn.lock ./
+COPY turbo.json ./
+COPY apps/websocket/package.json ./apps/websocket/
+
+# 개발 의존성 설치 (프로덕션 플래그 제거)
 RUN yarn install
 
-# Copy source
-COPY . .
-
-# Install app dependencies
-WORKDIR /app/apps/websocket
-RUN yarn install
+# 소스 코드는 볼륨으로 마운트할 예정이므로 COPY 불필요
 
 EXPOSE 4242
 
-# Start the application
+# WebSocket만 개발 모드로 실행
+WORKDIR /app/apps/websocket
 CMD ["yarn", "dev"] 


### PR DESCRIPTION
## 📋 Summary
octodocs.site 도메인으로 **최소한의 커맨드**로 프로덕션 배포 가능하도록 자동화 시스템을 구축했습니다.

## 🎯 주요 변경사항

### ✨ 새로운 기능
- **자체 완결형 배포**: PostgreSQL + Redis 컨테이너 포함, 외부 DB 의존성 제거
- **SSL 자동화**: Let's Encrypt 인증서 자동 발급 및 갱신
- **간편한 배포**: 2개 명령어로 완전한 프로덕션 배포 가능

### 🔧 개선사항
- Dockerfile 구조 일관성 개선 (Backend/WebSocket)
- Healthcheck 추가로 서비스 간 의존성 관리 개선
- Nginx 의존성을 Backend/WebSocket의 healthy 상태로 변경

## 📦 추가된 파일
- `compose.deploy.yml` - 프로덕션 배포용 Docker Compose 설정
- `scripts/deploy-init.sh` - SSL 인증서 자동 발급 스크립트
- `services/nginx/conf.d/default.deploy.conf` - 프로덕션 nginx 설정

## 🚀 배포 방법

### 사전 준비
1. Ubuntu 서버 준비 (Docker & Docker Compose 설치)
2. DNS 설정: `octodocs.site` A 레코드 → 서버 IP
3. 방화벽: 80, 443 포트 오픈

### 배포 단계
```bash
# 1. SSL 인증서 발급
yarn deploy:init

# 2. 프로덕션 배포
yarn deploy

# 3. 로그 확인
yarn deploy:logs
```

## 🔍 테스트 방법
- [ ] SSL 인증서 정상 발급 확인
- [ ] https://octodocs.site 접속 확인
- [ ] Backend API 정상 작동 확인
- [ ] WebSocket 연결 확인
- [ ] PostgreSQL/Redis 정상 작동 확인

## 📊 변경 파일
- `compose.local.yml` - Healthcheck 추가
- `package.json` - 배포 스크립트 추가
- `services/backend/Dockerfile.local` - CMD 수정
- `services/websocket/Dockerfile.local` - 구조 개선
- `compose.deploy.yml` - 신규 추가
- `scripts/deploy-init.sh` - 신규 추가
- `services/nginx/conf.d/default.deploy.conf` - 신규 추가

## 🎨 Architecture
```
Internet (HTTPS)
       ↓
   Nginx (443)
   + Let's Encrypt SSL
       ↓
   ┌────────┬────────┐
   ↓        ↓        ↓
Backend  WebSocket  Frontend
(3000)    (4242)    (5173)
   ↓        ↓
PostgreSQL + Redis
(자체 완결형)
```

## 💡 참고사항
- `compose.prod.yml`은 기존 프로덕션 환경 보존을 위해 수정하지 않음